### PR TITLE
Fix svc labels

### DIFF
--- a/charts/llm-inference-app/templates/_helpers.tpl
+++ b/charts/llm-inference-app/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Common labels
 {{- define "app.labels" -}}
 application: llm-inference
 helm.sh/chart: {{ include "app.chart" . }}
-{{ include "custom-deployment.selectorLabels" . }}
+{{ include "app.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}

--- a/charts/llm-inference-app/templates/_helpers.tpl
+++ b/charts/llm-inference-app/templates/_helpers.tpl
@@ -36,6 +36,7 @@ Common labels
 {{- define "app.labels" -}}
 application: llm-inference
 helm.sh/chart: {{ include "app.chart" . }}
+{{ include "custom-deployment.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}

--- a/charts/llm-inference-app/templates/deployment.yaml
+++ b/charts/llm-inference-app/templates/deployment.yaml
@@ -23,7 +23,6 @@ spec:
       labels:
         {{- include "app.labels" . | nindent 8 }}
         {{- include "app.apoloPodLabels" . | nindent 8 }}
-        {{- include "app.selectorLabels" . | nindent 8 }}
         {{- with .Values.podExtraLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
This pull request makes adjustments to the labeling logic in the Helm chart templates for the `llm-inference-app`. The changes primarily focus on streamlining the use of selector labels and improving label definitions in the deployment configuration.

Labeling adjustments:

* [`charts/llm-inference-app/templates/_helpers.tpl`](diffhunk://#diff-8909474c0b2cbb90e5aad8ad3acd625eea66de1935b2055fd3c1fc912a5c2c31R39): Added `app.selectorLabels` to the common label definitions to ensure consistent inclusion of selector labels across resources.
* [`charts/llm-inference-app/templates/deployment.yaml`](diffhunk://#diff-646d34a070949861d1a9c766afc2f0d4299d6ee6fe26bcb16fc0ea74ee341709L26): Removed the explicit inclusion of `app.selectorLabels` in the deployment's `spec.labels`, as it is now handled centrally in the common label definitions.