### PR TITLE
IT-13: Add backward compatibility with raw HF model as input

### DIFF
--- a/.apolo/src/apolo_apps_llm_inference/__init__.py
+++ b/.apolo/src/apolo_apps_llm_inference/__init__.py
@@ -1,22 +1,22 @@
+from apolo_apps_llm_inference.app_types import (
+    DeepSeekInputs,
+    GptOssInputs,
+    Kimi2Inputs,
+    LLama4Inputs,
+    MistralInputs,
+    VLLMInferenceInputs,
+    VLLMInferenceOutputs,
+)
 from apolo_apps_llm_inference.inputs_processor import (
-    VLLMInferenceInputsProcessor,
-    GPTOSSInferenceValueProcessor,
     DeepSeekInferenceValueProcessor,
+    GPTOSSInferenceValueProcessor,
+    Kimi2InferenceValueProcessor,
     Llama4InferenceValueProcessor,
     MistralInferenceValueProcessor,
-    Kimi2InferenceValueProcessor,
+    VLLMInferenceInputsProcessor,
 )
 from apolo_apps_llm_inference.outputs_processor import (
     VLLMInferenceOutputsProcessor,
-)
-from apolo_apps_llm_inference.app_types import (
-    VLLMInferenceInputs,
-    VLLMInferenceOutputs,
-    MistralInputs,
-    GptOssInputs,
-    DeepSeekInputs,
-    LLama4Inputs,
-    Kimi2Inputs,
 )
 
 

--- a/.apolo/src/apolo_apps_llm_inference/app_types.py
+++ b/.apolo/src/apolo_apps_llm_inference/app_types.py
@@ -2,28 +2,30 @@ import typing
 from enum import Enum
 from typing import Literal
 
+from pydantic import Field, model_validator
+
 from apolo_app_types import LLMModelConfig
 from apolo_app_types.protocols.common import (
     ApoloSecret,
     AppInputs,
     AppOutputs,
-    SchemaExtraMetadata,
-    ServiceAPI,
-    Preset,
-    SchemaMetaType,
-    IngressHttp,
-    Env,
     ContainerImage,
+    Env,
+    IngressHttp,
     OpenAICompatChatAPI,
     OpenAICompatEmbeddingsAPI,
-
+    Preset,
+    SchemaExtraMetadata,
+    SchemaMetaType,
+    ServiceAPI,
 )
 from apolo_app_types.protocols.common.autoscaling import AutoscalingKedaHTTP
 from apolo_app_types.protocols.common.containers import ContainerImagePullPolicy
-from apolo_app_types.protocols.common.hugging_face import HF_TOKEN_SCHEMA_EXTRA, HuggingFaceModelDetailDynamic, HuggingFaceModel
-from pydantic import Field
-from pydantic import model_validator
-
+from apolo_app_types.protocols.common.hugging_face import (
+    HF_TOKEN_SCHEMA_EXTRA,
+    HuggingFaceModel,
+    HuggingFaceModelDetailDynamic,
+)
 
 
 class VLLMInferenceInputs(AppInputs):

--- a/.apolo/src/apolo_apps_llm_inference/app_types.py
+++ b/.apolo/src/apolo_apps_llm_inference/app_types.py
@@ -38,7 +38,7 @@ class VLLMInferenceInputs(AppInputs):
             " over the internet using HTTPS.",
         ).as_json_schema_extra(),
     )
-    hugging_face_model: HuggingFaceModelDetailDynamic
+    hugging_face_model: HuggingFaceModel | HuggingFaceModelDetailDynamic
 
     tokenizer_hf_name: str = Field(  # noqa: N815
         "",
@@ -90,7 +90,12 @@ class VLLMInferenceInputs(AppInputs):
     @model_validator(mode="after")
     def check_autoscaling_requires_cache(self) -> "VLLMInferenceInputs":
         if self.http_autoscaling:
-            if self.hugging_face_model.files_path is None:
+            model = self.hugging_face_model
+            if isinstance(model, HuggingFaceModelDetailDynamic):
+                files_path = model.files_path
+            else:
+                files_path = model.hf_cache.files_path if model.hf_cache else None
+            if files_path is None:
                 msg = "If HTTP autoscaling is enabled, cache_config must also be set."
                 raise ValueError(msg)
         return self

--- a/.apolo/src/apolo_apps_llm_inference/app_types.py
+++ b/.apolo/src/apolo_apps_llm_inference/app_types.py
@@ -2,27 +2,25 @@ import typing
 from enum import Enum
 from typing import Literal
 
-from apolo_app_types import LLMModelConfig, ContainerImage
+from apolo_app_types import LLMModelConfig
 from apolo_app_types.protocols.common import (
     ApoloSecret,
     AppInputs,
-    SchemaExtraMetadata,
-    ServiceAPI
-)
-from apolo_app_types.protocols.common import (
     AppOutputs,
-    HuggingFaceModel,
-    IngressHttp,
+    SchemaExtraMetadata,
+    ServiceAPI,
     Preset,
     SchemaMetaType,
-)
-from apolo_app_types.protocols.common.autoscaling import AutoscalingKedaHTTP
-from apolo_app_types.protocols.common.hugging_face import HF_TOKEN_SCHEMA_EXTRA, HuggingFaceModelDetailDynamic
-from apolo_app_types.protocols.common.k8s import Env
-from apolo_app_types.protocols.common.openai_compat import (
+    IngressHttp,
+    Env,
+    ContainerImage,
     OpenAICompatChatAPI,
     OpenAICompatEmbeddingsAPI,
+
 )
+from apolo_app_types.protocols.common.autoscaling import AutoscalingKedaHTTP
+from apolo_app_types.protocols.common.containers import ContainerImagePullPolicy
+from apolo_app_types.protocols.common.hugging_face import HF_TOKEN_SCHEMA_EXTRA, HuggingFaceModelDetailDynamic, HuggingFaceModel
 from pydantic import Field
 from pydantic import model_validator
 
@@ -78,10 +76,14 @@ class VLLMInferenceInputs(AppInputs):
             is_advanced_field=True,
         ).as_json_schema_extra(),
     )
-    docker_image_config: ContainerImage | None = Field(
-        default=None,
+    docker_image_config: ContainerImage = Field(
+        default=ContainerImage(
+            repository="vllm/vllm-openai",
+            tag="v0.21.0",
+            pullPolicy=ContainerImagePullPolicy.IF_NOT_PRESENT,
+        ),
         json_schema_extra=SchemaExtraMetadata(
-            title="Docker Image Config",
+            title="vLLM Server Image",
             description="Override container image for vLLM.",
             is_advanced_field=True,
         ).as_json_schema_extra(),

--- a/.apolo/src/apolo_apps_llm_inference/inputs_processor.py
+++ b/.apolo/src/apolo_apps_llm_inference/inputs_processor.py
@@ -227,26 +227,36 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
         # No cache configured - use init container with emptyDir cache
         return download_via_init_values
 
-    def _configure_image(self, input_: VLLMInferenceInputs) -> dict[str, t.Any]:
-        if input_.docker_image_config:
-            return {
-                "image": {
-                    "repository": input_.docker_image_config.repository,
-                    "tag": input_.docker_image_config.tag,
-                    "pullPolicy": input_.docker_image_config.pull_policy,
-                },
-                "nvidiaImage": {
-                    "repository": input_.docker_image_config.repository,
-                    "tag": input_.docker_image_config.tag,
-                    "pullPolicy": input_.docker_image_config.pull_policy,
-                },
-                "amdImage": {
-                    "repository": input_.docker_image_config.repository,
-                    "tag": input_.docker_image_config.tag,
-                    "pullPolicy": input_.docker_image_config.pull_policy,
-                },
-            }
-        return {}
+    def _configure_image(
+        self,
+        input_: VLLMInferenceInputs,
+        gpu_provider: str,
+    ) -> dict[str, t.Any]:
+        match gpu_provider:
+            case "amd":
+                return {
+                    "amdImage": {
+                        "repository": input_.docker_image_config.repository,
+                        "tag": input_.docker_image_config.tag,
+                        "pullPolicy": input_.docker_image_config.pull_policy.value,
+                    },
+                }
+            case "nvidia":
+                return {
+                    "nvidiaImage": {
+                        "repository": input_.docker_image_config.repository,
+                        "tag": input_.docker_image_config.tag,
+                        "pullPolicy": input_.docker_image_config.pull_policy.value,
+                    },
+                }
+            case _:
+                return {
+                    "image": {
+                        "repository": input_.docker_image_config.repository,
+                        "tag": input_.docker_image_config.tag,
+                        "pullPolicy": input_.docker_image_config.pull_policy.value,
+                    },
+                }
 
     async def gen_extra_values(
         self,
@@ -285,7 +295,7 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
 
         gpu_count = nvidia_gpus + amd_gpus
         if amd_gpus > 0:
-            gpu_provider = "amd"
+            gpu_provider: str = "amd"
         elif nvidia_gpus > 0:
             gpu_provider = "nvidia"
         else:
@@ -297,7 +307,7 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
         parallel_args = self._configure_parallel_args(
             input_.server_extra_args, gpu_count
         )
-        image_config = self._configure_image(input_)
+        image_config = self._configure_image(input_, gpu_provider)
         server_extra_args = [
             *input_.server_extra_args,
             *parallel_args,

--- a/.apolo/src/apolo_apps_llm_inference/inputs_processor.py
+++ b/.apolo/src/apolo_apps_llm_inference/inputs_processor.py
@@ -232,12 +232,13 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
         input_: VLLMInferenceInputs,
         gpu_provider: str,
     ) -> dict[str, t.Any]:
+        fallback_tag = VLLMInferenceInputs.model_fields["docker_image_config"].default.tag
         match gpu_provider:
             case "amd":
                 return {
                     "amdImage": {
                         "repository": input_.docker_image_config.repository,
-                        "tag": input_.docker_image_config.tag,
+                        "tag": input_.docker_image_config.tag or fallback_tag,
                         "pullPolicy": input_.docker_image_config.pull_policy.value,
                     },
                 }
@@ -245,7 +246,7 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
                 return {
                     "nvidiaImage": {
                         "repository": input_.docker_image_config.repository,
-                        "tag": input_.docker_image_config.tag,
+                        "tag": input_.docker_image_config.tag or fallback_tag,
                         "pullPolicy": input_.docker_image_config.pull_policy.value,
                     },
                 }
@@ -253,7 +254,7 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
                 return {
                     "image": {
                         "repository": input_.docker_image_config.repository,
-                        "tag": input_.docker_image_config.tag,
+                        "tag": input_.docker_image_config.tag or fallback_tag,
                         "pullPolicy": input_.docker_image_config.pull_policy.value,
                     },
                 }

--- a/.apolo/src/apolo_apps_llm_inference/inputs_processor.py
+++ b/.apolo/src/apolo_apps_llm_inference/inputs_processor.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from typing import NamedTuple
 
 from apolo_app_types import HuggingFaceToken
-from apolo_app_types.protocols.common.hugging_face import HuggingFaceModelDetailDynamic
+from apolo_app_types.protocols.common.hugging_face import HuggingFaceModelDetailDynamic, HuggingFaceModel
 from apolo_app_types.app_types import AppType
 from apolo_app_types.helm.apps.base import BaseChartValueProcessor
 from apolo_app_types.helm.apps.common import (
@@ -121,8 +121,13 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
         return parallel_server_args
 
     def _configure_model(self, input_: VLLMInferenceInputs) -> dict[str, str]:
+        model = input_.hugging_face_model
+        if isinstance(model, HuggingFaceModelDetailDynamic):
+            model_hf_name = model.id
+        else:
+            model_hf_name = model.model_hf_name
         return {
-            "modelHFName": input_.hugging_face_model.id,
+            "modelHFName": model_hf_name,
             "tokenizerHFName": input_.tokenizer_hf_name,
         }
 
@@ -151,7 +156,11 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
 
     def _configure_extra_annotations(self, input_: VLLMInferenceInputs) -> dict[str, str]:
         extra_annotations: dict[str, str] = {}
-        cache_files_path = input_.hugging_face_model.files_path
+        model = input_.hugging_face_model
+        if isinstance(model, HuggingFaceModelDetailDynamic):
+           cache_files_path = model.files_path
+        else:
+            cache_files_path = model.hf_cache.files_path if model.hf_cache else None
         if cache_files_path:
             storage_mount = ApoloFilesMount(
                 storage_uri=cache_files_path,
@@ -165,7 +174,13 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
 
     def _configure_extra_labels(self, input_: VLLMInferenceInputs) -> dict[str, str]:
         extra_labels: dict[str, str] = {}
-        if input_.hugging_face_model.files_path is not None:
+        model = input_.hugging_face_model
+        if isinstance(model, HuggingFaceModelDetailDynamic):
+           cache_files_path = model.files_path
+        else:
+            cache_files_path = model.hf_cache.files_path if model.hf_cache else None
+
+        if cache_files_path is not None:
             extra_labels.update(
                 **gen_apolo_storage_integration_labels(
                     client=self.client, inject_storage=True
@@ -177,6 +192,17 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
         hf_model = input_.hugging_face_model
         # If model is already cached (cached=True and files_path set),
         # skip download entirely - model files are already on the storage mount
+        download_via_init_values = {
+            "modelDownload": {
+                "hookEnabled": False,
+                "initEnabled": True,
+            },
+            "cache": {
+                "enabled": True,
+            },
+        }
+        if not isinstance(hf_model, HuggingFaceModelDetailDynamic):
+            return download_via_init_values
         if hf_model.cached and hf_model.files_path is not None:
             return {
                 "modelDownload": {
@@ -199,15 +225,7 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
                 },
             }
         # No cache configured - use init container with emptyDir cache
-        return {
-            "modelDownload": {
-                "hookEnabled": False,
-                "initEnabled": True,
-            },
-            "cache": {
-                "enabled": True,
-            },
-        }
+        return download_via_init_values
 
     def _configure_image(self, input_: VLLMInferenceInputs) -> dict[str, t.Any]:
         if input_.docker_image_config:

--- a/.apolo/src/apolo_apps_llm_inference/inputs_processor.py
+++ b/.apolo/src/apolo_apps_llm_inference/inputs_processor.py
@@ -198,7 +198,7 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
                 "initEnabled": True,
             },
             "cache": {
-                "enabled": True,
+                "enabled": False,
             },
         }
         if not isinstance(hf_model, HuggingFaceModelDetailDynamic):

--- a/.apolo/src/apolo_apps_llm_inference/inputs_processor.py
+++ b/.apolo/src/apolo_apps_llm_inference/inputs_processor.py
@@ -3,8 +3,9 @@ import typing as t
 from decimal import Decimal
 from typing import NamedTuple
 
+from apolo_sdk import Preset as SDKPreset
+
 from apolo_app_types import HuggingFaceToken
-from apolo_app_types.protocols.common.hugging_face import HuggingFaceModelDetailDynamic, HuggingFaceModel
 from apolo_app_types.app_types import AppType
 from apolo_app_types.helm.apps.base import BaseChartValueProcessor
 from apolo_app_types.helm.apps.common import (
@@ -15,34 +16,33 @@ from apolo_app_types.helm.apps.common import (
     get_preset,
 )
 from apolo_app_types.helm.utils.deep_merging import merge_list_of_dicts
-
 from apolo_app_types.protocols.common import (
     ApoloFilesMount,
-    ApoloMountMode,
-    MountPath,
-)
-from apolo_app_types.protocols.common import (
     ApoloFilesPath,
+    ApoloMountMode,
     IngressHttp,
+    MountPath,
     NoAuth,
     Preset,
 )
 from apolo_app_types.protocols.common.autoscaling import AutoscalingKedaHTTP
+from apolo_app_types.protocols.common.hugging_face import (
+    HuggingFaceModelDetailDynamic,
+)
 from apolo_app_types.protocols.common.secrets_ import serialize_optional_secret
 from apolo_app_types.protocols.common.storage import ApoloMountModes
-from apolo_sdk import Preset as SDKPreset
 from apolo_apps_llm_inference.app_types import (
-    VLLMInferenceInputs,
     DeepSeekInputs,
     DeepSeekSize,
+    GptOssInputs,
     GptOssSize,
+    Kimi2Inputs,
+    Kimi2Size,
     LLama4Inputs,
     Llama4Size,
     MistralInputs,
     MistralSize,
-    GptOssInputs,
-    Kimi2Inputs,
-    Kimi2Size,
+    VLLMInferenceInputs,
 )
 
 
@@ -138,8 +138,7 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
         hf_token = input_.hugging_face_model.hf_token
         env_vars = {
             "HUGGING_FACE_HUB_TOKEN": serialize_optional_secret(
-                hf_token.token if hf_token else None,
-                secret_name=app_secrets_name
+                hf_token.token if hf_token else None, secret_name=app_secrets_name
             )
         }
 
@@ -154,11 +153,13 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
 
         return env_vars
 
-    def _configure_extra_annotations(self, input_: VLLMInferenceInputs) -> dict[str, str]:
+    def _configure_extra_annotations(
+        self, input_: VLLMInferenceInputs
+    ) -> dict[str, str]:
         extra_annotations: dict[str, str] = {}
         model = input_.hugging_face_model
         if isinstance(model, HuggingFaceModelDetailDynamic):
-           cache_files_path = model.files_path
+            cache_files_path = model.files_path
         else:
             cache_files_path = model.hf_cache.files_path if model.hf_cache else None
         if cache_files_path:
@@ -176,7 +177,7 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
         extra_labels: dict[str, str] = {}
         model = input_.hugging_face_model
         if isinstance(model, HuggingFaceModelDetailDynamic):
-           cache_files_path = model.files_path
+            cache_files_path = model.files_path
         else:
             cache_files_path = model.hf_cache.files_path if model.hf_cache else None
 
@@ -188,7 +189,9 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
             )
         return extra_labels
 
-    def _configure_model_download(self, input_: VLLMInferenceInputs) -> dict[str, t.Any]:
+    def _configure_model_download(
+        self, input_: VLLMInferenceInputs
+    ) -> dict[str, t.Any]:
         hf_model = input_.hugging_face_model
         # If model is already cached (cached=True and files_path set),
         # skip download entirely - model files are already on the storage mount
@@ -198,10 +201,13 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
                 "initEnabled": True,
             },
             "cache": {
-                "enabled": False,
+                "enabled": True,
             },
         }
         if not isinstance(hf_model, HuggingFaceModelDetailDynamic):
+            if hf_model.hf_cache and hf_model.hf_cache.files_path is not None:
+                download_via_init_values["cache"]["enabled"] = False
+                return download_via_init_values
             return download_via_init_values
         if hf_model.cached and hf_model.files_path is not None:
             return {
@@ -232,7 +238,9 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
         input_: VLLMInferenceInputs,
         gpu_provider: str,
     ) -> dict[str, t.Any]:
-        fallback_tag = VLLMInferenceInputs.model_fields["docker_image_config"].default.tag
+        fallback_tag = VLLMInferenceInputs.model_fields[
+            "docker_image_config"
+        ].default.tag
         match gpu_provider:
             case "amd":
                 return {
@@ -331,12 +339,15 @@ class VLLMInferenceInputsProcessor(BaseChartValueProcessor[VLLMInferenceInputs])
             ]
         )
 
+
 class ModelSettings(NamedTuple):
     model_hf_name: str
     vram_min_required_gb: float
 
 
-T = t.TypeVar("T", LLama4Inputs, DeepSeekInputs, MistralInputs, GptOssInputs, Kimi2Inputs)
+T = t.TypeVar(
+    "T", LLama4Inputs, DeepSeekInputs, MistralInputs, GptOssInputs, Kimi2Inputs
+)
 
 
 logger = logging.getLogger(__name__)
@@ -434,8 +445,7 @@ class BaseLLMBundleMixin(BaseChartValueProcessor[T]):
             id=model_settings.model_hf_name,
             visibility="public",
             hf_token=HuggingFaceToken(
-                token_name="llm_bundle_token",
-                token=input_.hf_token
+                token_name="llm_bundle_token", token=input_.hf_token
             ),
             files_path=ApoloFilesPath(path=self._get_storage_path()),
             cached=False,

--- a/.apolo/src/apolo_apps_llm_inference/outputs_processor.py
+++ b/.apolo/src/apolo_apps_llm_inference/outputs_processor.py
@@ -110,6 +110,7 @@ class VLLMInferenceOutputsProcessor(
         except Exception as err:
             # swallow and try next priority
             pass
+        return None
 
     async def _generate_outputs(
         self,

--- a/.apolo/src/apolo_apps_llm_inference/outputs_processor.py
+++ b/.apolo/src/apolo_apps_llm_inference/outputs_processor.py
@@ -1,21 +1,22 @@
 import logging
 import typing as t
 
+from apolo_app_types import HuggingFaceModel, LLMModelConfig
 from apolo_app_types.outputs.base import BaseAppOutputsProcessor
-from apolo_app_types import LLMModelConfig, HuggingFaceModel
 from apolo_app_types.outputs.common import (
-    get_service_host_port,
-    get_ingress_host_port,
     INSTANCE_LABEL,
+    get_ingress_host_port,
+    get_service_host_port,
 )
 from apolo_app_types.outputs.llm import parse_cli_args
 from apolo_app_types.protocols.common.openai_compat import (
     OpenAICompatChatAPI,
     OpenAICompatEmbeddingsAPI,
 )
-from .app_types import VLLMInferenceOutputs
 
+from .app_types import VLLMInferenceOutputs
 from .utils import fetch_max_model_len_from_server, parse_max_model_len
+
 
 logger = logging.getLogger(__name__)
 
@@ -51,12 +52,16 @@ async def get_llm_inference_outputs(
     embeddings_external = None
     if ingress_host_port:
         chat_external = OpenAICompatChatAPI(
-            host=ingress_host_port[0], port=int(ingress_host_port[1]),
-            protocol="https", hf_model=hf_model
+            host=ingress_host_port[0],
+            port=int(ingress_host_port[1]),
+            protocol="https",
+            hf_model=hf_model,
         )
         embeddings_external = OpenAICompatEmbeddingsAPI(
-            host=ingress_host_port[0], port=int(ingress_host_port[1]),
-            protocol="https", hf_model=hf_model
+            host=ingress_host_port[0],
+            port=int(ingress_host_port[1]),
+            protocol="https",
+            hf_model=hf_model,
         )
 
     return {
@@ -66,7 +71,9 @@ async def get_llm_inference_outputs(
         },
         "embeddings_api": {
             "internal_url": embeddings_internal.model_dump(),
-            "external_url": embeddings_external.model_dump() if embeddings_external else None,
+            "external_url": embeddings_external.model_dump()
+            if embeddings_external
+            else None,
         },
         "hugging_face_model": hf_model.model_dump(),
         "tokenizer_hf_name": tokenizer_name,
@@ -75,11 +82,10 @@ async def get_llm_inference_outputs(
     }
 
 
-class VLLMInferenceOutputsProcessor(
-    BaseAppOutputsProcessor[VLLMInferenceOutputs]
-):
-    async def _get_model_config(self, helm_values: dict[str, t.Any],
-                                vllm_outputs_dict: dict[str, t.Any]) -> LLMModelConfig | None:
+class VLLMInferenceOutputsProcessor(BaseAppOutputsProcessor[VLLMInferenceOutputs]):
+    async def _get_model_config(
+        self, helm_values: dict[str, t.Any], vllm_outputs_dict: dict[str, t.Any]
+    ) -> LLMModelConfig | None:
         # priority 1: --max-model-len from server args
         hf_model_name = helm_values["model"]["modelHFName"]
         api_key = None
@@ -97,17 +103,22 @@ class VLLMInferenceOutputsProcessor(
                     api_key = arg.split("=", 1)[-1]
 
         # priority 2: ask the INTERNAL server /v1/models
-        internal_host, internal_port = (vllm_outputs_dict["chat_api"]["internal_url"]["host"],
-                                        vllm_outputs_dict["chat_api"]["internal_url"]["port"])
+        internal_host, internal_port = (
+            vllm_outputs_dict["chat_api"]["internal_url"]["host"],
+            vllm_outputs_dict["chat_api"]["internal_url"]["port"],
+        )
         try:
             server_len = await fetch_max_model_len_from_server(
-                internal_host, int(internal_port), expected_model_id=hf_model_name, api_key=api_key
+                internal_host,
+                int(internal_port),
+                expected_model_id=hf_model_name,
+                api_key=api_key,
             )
             if server_len:
                 return LLMModelConfig(
                     context_max_tokens=server_len,
                 )
-        except Exception as err:
+        except Exception:
             # swallow and try next priority
             pass
         return None
@@ -117,12 +128,10 @@ class VLLMInferenceOutputsProcessor(
         helm_values: dict[str, t.Any],
         app_instance_id: str,
     ) -> VLLMInferenceOutputs:
-
         outputs = await get_llm_inference_outputs(helm_values, app_instance_id)
         model_config = await self._get_model_config(helm_values, outputs)
         msg = f"Got outputs: {outputs}"
         logger.info(msg)
-        return VLLMInferenceOutputs.model_validate({
-            **outputs,
-            "llm_model_config": model_config
-        })
+        return VLLMInferenceOutputs.model_validate(
+            {**outputs, "llm_model_config": model_config}
+        )

--- a/.apolo/src/apolo_apps_llm_inference/schemas/VLLMInferenceInputs.json
+++ b/.apolo/src/apolo_apps_llm_inference/schemas/VLLMInferenceInputs.json
@@ -734,20 +734,17 @@
       "x-title": "HTTP Autoscaling"
     },
     "docker_image_config": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/ContainerImage"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
+      "$ref": "#/$defs/ContainerImage",
+      "default": {
+        "repository": "vllm/vllm-openai",
+        "tag": "v0.21.0",
+        "dockerconfigjson": null,
+        "pull_policy": "IfNotPresent",
+        "__type__": "ContainerImage"
+      },
       "x-description": "Override container image for vLLM.",
       "x-is-advanced-field": true,
-      "x-is-configurable": true,
-      "x-meta-type": "inline",
-      "x-title": "Docker Image Config"
+      "x-title": "vLLM Server Image"
     }
   },
   "required": [

--- a/.apolo/src/apolo_apps_llm_inference/schemas/VLLMInferenceInputs.json
+++ b/.apolo/src/apolo_apps_llm_inference/schemas/VLLMInferenceInputs.json
@@ -313,6 +313,83 @@
       "x-title": "Env",
       "x-type": "Env"
     },
+    "HuggingFaceCache": {
+      "properties": {
+        "files_path": {
+          "$ref": "#/$defs/ApoloFilesPath",
+          "default": {
+            "path": "storage:.apps/hugging-face-cache",
+            "__type__": "ApoloFilesPath"
+          },
+          "x-description": "The path to the Apolo Files directory where Hugging Face artifacts are cached.",
+          "x-title": "Files Path"
+        }
+      },
+      "title": "HuggingFaceCache",
+      "type": "object",
+      "x-description": "Configuration for the Hugging Face cache.",
+      "x-is-advanced-field": false,
+      "x-is-configurable": true,
+      "x-meta-type": "integration",
+      "x-title": "Hugging Face Cache",
+      "x-type": "HuggingFaceCache"
+    },
+    "HuggingFaceModel": {
+      "properties": {
+        "model_hf_name": {
+          "title": "Model Hf Name",
+          "type": "string",
+          "x-description": "The name of the Hugging Face model.",
+          "x-is-advanced-field": false,
+          "x-is-configurable": true,
+          "x-meta-type": "inline",
+          "x-title": "Hugging Face Model Name"
+        },
+        "hf_token": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HuggingFaceToken"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "x-description": "Provide a Hugging Face API token linked to an account with access to the model specified above. This token will be used to download model files from the Hugging Face Hub, including gated or private repositories where applicable.",
+          "x-is-advanced-field": false,
+          "x-is-configurable": true,
+          "x-meta-type": "integration",
+          "x-title": "Hugging Face Token"
+        },
+        "hf_cache": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HuggingFaceCache"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "x-description": "Enables caching of model files to reduce redundant downloads and speed up load times.",
+          "x-is-advanced-field": false,
+          "x-is-configurable": true,
+          "x-meta-type": "inline",
+          "x-title": "Model Cache"
+        }
+      },
+      "required": [
+        "model_hf_name"
+      ],
+      "title": "HuggingFaceModel",
+      "type": "object",
+      "x-description": "Configure the Hugging Face model. Ensure it is available on the Hugging Face Hub and provide an API token with access rights if the repository is gated.",
+      "x-is-advanced-field": false,
+      "x-is-configurable": true,
+      "x-meta-type": "integration",
+      "x-title": "Hugging Face Model",
+      "x-type": "HuggingFaceModel"
+    },
     "HuggingFaceModelDetailDynamic": {
       "description": "Detailed HuggingFace model information.",
       "properties": {
@@ -596,7 +673,15 @@
       "x-title": "Public HTTP Ingress"
     },
     "hugging_face_model": {
-      "$ref": "#/$defs/HuggingFaceModelDetailDynamic"
+      "anyOf": [
+        {
+          "$ref": "#/$defs/HuggingFaceModel"
+        },
+        {
+          "$ref": "#/$defs/HuggingFaceModelDetailDynamic"
+        }
+      ],
+      "title": "Hugging Face Model"
     },
     "tokenizer_hf_name": {
       "default": "",

--- a/.apolo/src/apolo_apps_llm_inference/utils.py
+++ b/.apolo/src/apolo_apps_llm_inference/utils.py
@@ -2,6 +2,7 @@ import typing as t
 
 import httpx
 
+
 async def fetch_max_model_len_from_server(
     host: str,
     port: int,
@@ -11,7 +12,8 @@ async def fetch_max_model_len_from_server(
     timeout_s: float = 5.0,
 ) -> int | None:
     """
-    Query the internal vLLM server /v1/models and return max_model_len for the expected model.
+    Query the internal vLLM server /v1/models and
+    return max_model_len for the expected model.
     Tries to match by id, then by root field.
     """
     url = f"http://{host}:{port}/v1/models"
@@ -39,7 +41,7 @@ async def fetch_max_model_len_from_server(
     return int(val) if isinstance(val, int) else None
 
 
-def parse_max_model_len(raw: t.Any) -> int:
+def parse_max_model_len(raw: t.Any) -> int:  # noqa: C901
     """
     Parse values like:
       131072      -> 131072
@@ -51,29 +53,38 @@ def parse_max_model_len(raw: t.Any) -> int:
       "2G"        -> 2147483648
     Only the last character is checked for unit: k/m/g (decimal) or K/M/G (binary).
     """
-    if isinstance(raw, (int, float)):
+    if isinstance(raw, int | float):
         return int(raw)
 
     s = str(raw).strip()
     if not s:
-        raise ValueError("empty max model len")
+        e = "empty max model len"
+        raise ValueError(e)
 
     last = s[-1]
-    if last.isdigit():                   # no unit, pure number
+    if last.isdigit():  # no unit, pure number
         return int(float(s))
 
     num_str = s[:-1].strip()
     if not num_str:
-        raise ValueError(f"invalid number: {raw!r}")
+        e = f"invalid number: {raw!r}"
+        raise ValueError(e)
     num = float(num_str)
 
-    if last == "k": mult = 10**3
-    elif last == "m": mult = 10**6
-    elif last == "g": mult = 10**9
-    elif last == "K": mult = 1 << 10
-    elif last == "M": mult = 1 << 20
-    elif last == "G": mult = 1 << 30
+    if last == "k":
+        mult = 10**3
+    elif last == "m":
+        mult = 10**6
+    elif last == "g":
+        mult = 10**9
+    elif last == "K":
+        mult = 1 << 10
+    elif last == "M":
+        mult = 1 << 20
+    elif last == "G":
+        mult = 1 << 30
     else:
-        raise ValueError(f"unknown unit: {last!r}")
+        e = f"invalid unit: {last!r}"
+        raise ValueError(e)
 
     return int(num * mult)

--- a/.apolo/src/apolo_apps_llm_inference/utils.py
+++ b/.apolo/src/apolo_apps_llm_inference/utils.py
@@ -1,5 +1,6 @@
-import httpx
+import typing as t
 
+import httpx
 
 async def fetch_max_model_len_from_server(
     host: str,
@@ -22,7 +23,7 @@ async def fetch_max_model_len_from_server(
         r.raise_for_status()
         payload = r.json()
 
-    models: list[dict] = payload.get("data", [])
+    models: list[dict[str, t.Any]] = payload.get("data", [])
     # Prefer exact id match, then root match, else first model
     candidates = (
         [m for m in models if m.get("id") == expected_model_id]
@@ -38,7 +39,7 @@ async def fetch_max_model_len_from_server(
     return int(val) if isinstance(val, int) else None
 
 
-def parse_max_model_len(raw) -> int:
+def parse_max_model_len(raw: t.Any) -> int:
     """
     Parse values like:
       131072      -> 131072

--- a/.apolo/tests/conftest.py
+++ b/.apolo/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from apolo_sdk import Preset
 from neuro_config_client import NvidiaGPUPreset
 
+
 pytest_plugins = [
     "apolo_app_types_fixtures.apolo_clients",
     "apolo_app_types_fixtures.constants",
@@ -63,7 +64,7 @@ TEST_PRESETS_WITH_GGUF_SUPPORT = {
 
 
 @pytest.fixture
-def mock_get_preset_gpu_h100(setup_clients):
+def _mock_get_preset_gpu_h100(setup_clients):
     """Fixture that provides H100 8x GPU cluster preset for V3.2 model testing."""
     from unittest.mock import AsyncMock
 
@@ -74,7 +75,7 @@ def mock_get_preset_gpu_h100(setup_clients):
 
 
 @pytest.fixture
-def mock_get_preset_gpu_gguf(setup_clients):
+def _mock_get_preset_gpu_gguf(setup_clients):
     """Fixture that provides presets for GGUF quantized models with varying VRAM."""
     from unittest.mock import AsyncMock
 
@@ -85,7 +86,7 @@ def mock_get_preset_gpu_gguf(setup_clients):
 
 
 @pytest.fixture
-def mock_fetch_models(monkeypatch):
+def _mock_fetch_models(monkeypatch):
     """
     Monkeypatch load_hf_json(model, filename) to return canned dicts.
     Adjust the returned dicts to match your scenarios.
@@ -93,7 +94,7 @@ def mock_fetch_models(monkeypatch):
 
     async def _fake_fetch_max_model_len(*_, **__):
         return 131_072  # simulate vLLM reporting this limit
-    from apolo_apps_llm_inference import utils, outputs_processor
+
     monkeypatch.setattr(
         "apolo_apps_llm_inference.outputs_processor.fetch_max_model_len_from_server",
         _fake_fetch_max_model_len,

--- a/.apolo/tests/unit/bundles/test_deepseek_input_generation.py
+++ b/.apolo/tests/unit/bundles/test_deepseek_input_generation.py
@@ -124,6 +124,11 @@ async def test_values_llm_generation_gpu_default_preset(
         "modelDownload": {"hookEnabled": True, "initEnabled": False},
         "cache": {"enabled": False},
         "gpuProvider": "nvidia",
+        "nvidiaImage": {
+            "pullPolicy": "IfNotPresent",
+            "repository": "vllm/vllm-openai",
+            "tag": "v0.21.0"
+        },
         "podLabels": {
             "platform.apolo.us/component": "app",
             "platform.apolo.us/preset": preset_name,

--- a/.apolo/tests/unit/bundles/test_deepseek_input_generation.py
+++ b/.apolo/tests/unit/bundles/test_deepseek_input_generation.py
@@ -1,3 +1,12 @@
+import pytest
+from apolo_app_types_fixtures.constants import (
+    APP_ID,
+    APP_SECRETS_NAME,
+    DEFAULT_NAMESPACE,
+)
+from apolo_apps_llm_inference import DeepSeekInferenceValueProcessor
+from apolo_apps_llm_inference.app_types import DeepSeekInputs, DeepSeekSize
+
 from apolo_app_types.app_types import AppType
 from apolo_app_types.helm.apps.bundles.llm import DeepSeekValueProcessor
 from apolo_app_types.helm.apps.common import (
@@ -7,12 +16,6 @@ from apolo_app_types.helm.apps.common import (
 )
 from apolo_app_types.protocols.common import ApoloSecret
 
-from apolo_app_types_fixtures.constants import APP_ID, APP_SECRETS_NAME, DEFAULT_NAMESPACE
-
-from apolo_apps_llm_inference import DeepSeekInferenceValueProcessor
-from apolo_apps_llm_inference.app_types import DeepSeekInputs, DeepSeekSize
-
-
 
 async def test_values_llm_generation_gpu_default_preset(
     setup_clients, mock_get_preset_gpu
@@ -20,9 +23,7 @@ async def test_values_llm_generation_gpu_default_preset(
     model_to_test = DeepSeekSize.r1_distill_qwen_1_5_b
     preset_name = "t4-medium"
     apolo_client = setup_clients
-    input_processor = DeepSeekInferenceValueProcessor(
-        client=apolo_client
-    )
+    input_processor = DeepSeekInferenceValueProcessor(client=apolo_client)
     helm_params = await input_processor.gen_extra_values(
         input_=DeepSeekInputs(
             size=model_to_test,
@@ -35,124 +36,126 @@ async def test_values_llm_generation_gpu_default_preset(
         app_id=APP_ID,
     )
 
-    assert helm_params == {
-        "serverExtraArgs": [],
-        "model": {
-            "modelHFName": DeepSeekValueProcessor.model_map[
-                model_to_test
-            ].model_hf_name,
-            "tokenizerHFName": DeepSeekValueProcessor.model_map[
-                model_to_test
-            ].model_hf_name,
-        },
-        "llm": {
-            "modelHFName": DeepSeekValueProcessor.model_map[
-                model_to_test
-            ].model_hf_name,
-            "tokenizerHFName": DeepSeekValueProcessor.model_map[
-                model_to_test
-            ].model_hf_name,
-        },
-        "env": {
-            "HUGGING_FACE_HUB_TOKEN": {
-                "valueFrom": {
-                    "secretKeyRef": {"name": "apps-secrets", "key": "FakeSecret"}
+    assert (
+        helm_params
+        == {
+            "serverExtraArgs": [],
+            "model": {
+                "modelHFName": DeepSeekValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+                "tokenizerHFName": DeepSeekValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+            },
+            "llm": {
+                "modelHFName": DeepSeekValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+                "tokenizerHFName": DeepSeekValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+            },
+            "env": {
+                "HUGGING_FACE_HUB_TOKEN": {
+                    "valueFrom": {
+                        "secretKeyRef": {"name": "apps-secrets", "key": "FakeSecret"}
+                    }
                 }
-            }
-        },
-        "preset_name": preset_name,
-        "resources": {
-            "requests": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
-            "limits": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
-        },
-        "tolerations": [
-            {
-                "effect": "NoSchedule",
-                "key": "platform.neuromation.io/job",
-                "operator": "Exists",
             },
-            {
-                "effect": "NoExecute",
-                "key": "node.kubernetes.io/not-ready",
-                "operator": "Exists",
-                "tolerationSeconds": 300,
+            "preset_name": preset_name,
+            "resources": {
+                "requests": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
+                "limits": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
             },
-            {
-                "effect": "NoExecute",
-                "key": "node.kubernetes.io/unreachable",
-                "operator": "Exists",
-                "tolerationSeconds": 300,
-            },
-            {"effect": "NoSchedule", "key": "nvidia.com/gpu", "operator": "Exists"},
-        ],
-        "affinity": {
-            "nodeAffinity": {
-                "requiredDuringSchedulingIgnoredDuringExecution": {
-                    "nodeSelectorTerms": [
-                        {
-                            "matchExpressions": [
-                                {
-                                    "key": "platform.neuromation.io/nodepool",
-                                    "operator": "In",
-                                    "values": ["gpu_pool"],
-                                }
-                            ]
-                        }
-                    ]
-                }
-            }
-        },
-        "ingress": {
-            "grpc": {"enabled": False},
-            "enabled": True,
-            "className": "traefik",
-            "hosts": [
+            "tolerations": [
                 {
-                    "host": f"{AppType.DeepSeek.value}--{APP_ID}.apps.some.org.neu.ro",
-                    "paths": [{"path": "/", "pathType": "Prefix", "portName": "http"}],
-                }
+                    "effect": "NoSchedule",
+                    "key": "platform.neuromation.io/job",
+                    "operator": "Exists",
+                },
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/not-ready",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300,
+                },
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/unreachable",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300,
+                },
+                {"effect": "NoSchedule", "key": "nvidia.com/gpu", "operator": "Exists"},
             ],
-        },
-        "podAnnotations": {
-            APOLO_STORAGE_LABEL: '[{"storage_uri": "storage://cluster/test-org/test-project/llm_bundles", "mount_path": "/root/.cache/huggingface", "mount_mode": "rw"}]'  # noqa: E501
-        },
-        "podExtraLabels": {
-            APOLO_STORAGE_LABEL: "true",
-            APOLO_ORG_LABEL: "test-org",
-            APOLO_PROJECT_LABEL: "test-project",
-        },
-        "modelDownload": {"hookEnabled": True, "initEnabled": False},
-        "cache": {"enabled": False},
-        "gpuProvider": "nvidia",
-        "nvidiaImage": {
-            "pullPolicy": "IfNotPresent",
-            "repository": "vllm/vllm-openai",
-            "tag": "v0.21.0"
-        },
-        "podLabels": {
-            "platform.apolo.us/component": "app",
-            "platform.apolo.us/preset": preset_name,
-        },
-        "apolo_app_id": APP_ID,
-        "envNvidia": {
-            "PATH": "/usr/local/cuda/bin:/usr/local/sbin:"
-            "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(PATH)",
-            "LD_LIBRARY_PATH": "/usr/local/cuda/lib64:"
-            "/usr/local/nvidia/lib64:$(LD_LIBRARY_PATH)",
-        },
-    }
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "platform.neuromation.io/nodepool",
+                                        "operator": "In",
+                                        "values": ["gpu_pool"],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "ingress": {
+                "grpc": {"enabled": False},
+                "enabled": True,
+                "className": "traefik",
+                "hosts": [
+                    {
+                        "host": f"{AppType.DeepSeek.value}--{APP_ID}.apps.some.org.neu.ro",  # noqa: E501
+                        "paths": [
+                            {"path": "/", "pathType": "Prefix", "portName": "http"}
+                        ],
+                    }
+                ],
+            },
+            "podAnnotations": {
+                APOLO_STORAGE_LABEL: '[{"storage_uri": "storage://cluster/test-org/test-project/llm_bundles", "mount_path": "/root/.cache/huggingface", "mount_mode": "rw"}]'  # noqa: E501
+            },
+            "podExtraLabels": {
+                APOLO_STORAGE_LABEL: "true",
+                APOLO_ORG_LABEL: "test-org",
+                APOLO_PROJECT_LABEL: "test-project",
+            },
+            "modelDownload": {"hookEnabled": True, "initEnabled": False},
+            "cache": {"enabled": False},
+            "gpuProvider": "nvidia",
+            "nvidiaImage": {
+                "pullPolicy": "IfNotPresent",
+                "repository": "vllm/vllm-openai",
+                "tag": "v0.21.0",
+            },
+            "podLabels": {
+                "platform.apolo.us/component": "app",
+                "platform.apolo.us/preset": preset_name,
+            },
+            "apolo_app_id": APP_ID,
+            "envNvidia": {
+                "PATH": "/usr/local/cuda/bin:/usr/local/sbin:"
+                "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(PATH)",
+                "LD_LIBRARY_PATH": "/usr/local/cuda/lib64:"
+                "/usr/local/nvidia/lib64:$(LD_LIBRARY_PATH)",
+            },
+        }
+    )
 
 
-async def test_values_llm_generation_v32_model(
-    setup_clients, mock_get_preset_gpu_h100
-):
+@pytest.mark.usefixtures("_mock_get_preset_gpu_h100")
+async def test_values_llm_generation_v32_model(setup_clients):
     """Test V3.2 model generates correct helm values with large GPU preset."""
     model_to_test = DeepSeekSize.v3_2
     preset_name = "h100-8x"
     apolo_client = setup_clients
-    input_processor = DeepSeekInferenceValueProcessor(
-        client=apolo_client
-    )
+    input_processor = DeepSeekInferenceValueProcessor(client=apolo_client)
     helm_params = await input_processor.gen_extra_values(
         input_=DeepSeekInputs(
             size=model_to_test,

--- a/.apolo/tests/unit/bundles/test_gptoss_input_generation.py
+++ b/.apolo/tests/unit/bundles/test_gptoss_input_generation.py
@@ -1,4 +1,11 @@
-from apolo_app_types import HuggingFaceToken
+from apolo_app_types_fixtures.constants import (
+    APP_ID,
+    APP_SECRETS_NAME,
+    DEFAULT_NAMESPACE,
+)
+from apolo_apps_llm_inference import GPTOSSInferenceValueProcessor
+from apolo_apps_llm_inference.app_types import GptOssInputs, GptOssSize
+
 from apolo_app_types.app_types import AppType
 from apolo_app_types.helm.apps.bundles.llm import (
     GPTOSSValueProcessor,
@@ -8,13 +15,8 @@ from apolo_app_types.helm.apps.common import (
     APOLO_PROJECT_LABEL,
     APOLO_STORAGE_LABEL,
 )
-
 from apolo_app_types.protocols.common import ApoloSecret
 
-from apolo_app_types_fixtures.constants import APP_ID, APP_SECRETS_NAME, DEFAULT_NAMESPACE
-
-from apolo_apps_llm_inference import GPTOSSInferenceValueProcessor
-from apolo_apps_llm_inference.app_types import GptOssInputs, GptOssSize
 
 async def test_values_llm_generation_gpu_default_preset(
     setup_clients, mock_get_preset_gpu
@@ -22,9 +24,7 @@ async def test_values_llm_generation_gpu_default_preset(
     model_to_test = GptOssSize.gpt_oss_20b
     preset_name = "t4-medium"
     apolo_client = setup_clients
-    input_processor = GPTOSSInferenceValueProcessor(
-        client=apolo_client
-    )
+    input_processor = GPTOSSInferenceValueProcessor(client=apolo_client)
     helm_params = await input_processor.gen_extra_values(
         input_=GptOssInputs(
             size=model_to_test,
@@ -37,105 +37,114 @@ async def test_values_llm_generation_gpu_default_preset(
         app_id=APP_ID,
     )
 
-    assert helm_params == {
-        "serverExtraArgs": [],
-        "model": {
-            "modelHFName": GPTOSSValueProcessor.model_map[model_to_test].model_hf_name,
-            "tokenizerHFName": GPTOSSValueProcessor.model_map[
-                model_to_test
-            ].model_hf_name,
-        },
-        "llm": {
-            "modelHFName": GPTOSSValueProcessor.model_map[model_to_test].model_hf_name,
-            "tokenizerHFName": GPTOSSValueProcessor.model_map[
-                model_to_test
-            ].model_hf_name,
-        },
-        "env": {
-            "HUGGING_FACE_HUB_TOKEN": {
-                "valueFrom": {
-                    "secretKeyRef": {"name": "apps-secrets", "key": "FakeSecret"}
+    assert (
+        helm_params
+        == {
+            "serverExtraArgs": [],
+            "model": {
+                "modelHFName": GPTOSSValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+                "tokenizerHFName": GPTOSSValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+            },
+            "llm": {
+                "modelHFName": GPTOSSValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+                "tokenizerHFName": GPTOSSValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+            },
+            "env": {
+                "HUGGING_FACE_HUB_TOKEN": {
+                    "valueFrom": {
+                        "secretKeyRef": {"name": "apps-secrets", "key": "FakeSecret"}
+                    }
                 }
-            }
-        },
-        "preset_name": preset_name,
-        "resources": {
-            "requests": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
-            "limits": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
-        },
-        "tolerations": [
-            {
-                "effect": "NoSchedule",
-                "key": "platform.neuromation.io/job",
-                "operator": "Exists",
             },
-            {
-                "effect": "NoExecute",
-                "key": "node.kubernetes.io/not-ready",
-                "operator": "Exists",
-                "tolerationSeconds": 300,
+            "preset_name": preset_name,
+            "resources": {
+                "requests": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
+                "limits": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
             },
-            {
-                "effect": "NoExecute",
-                "key": "node.kubernetes.io/unreachable",
-                "operator": "Exists",
-                "tolerationSeconds": 300,
-            },
-            {"effect": "NoSchedule", "key": "nvidia.com/gpu", "operator": "Exists"},
-        ],
-        "affinity": {
-            "nodeAffinity": {
-                "requiredDuringSchedulingIgnoredDuringExecution": {
-                    "nodeSelectorTerms": [
-                        {
-                            "matchExpressions": [
-                                {
-                                    "key": "platform.neuromation.io/nodepool",
-                                    "operator": "In",
-                                    "values": ["gpu_pool"],
-                                }
-                            ]
-                        }
-                    ]
-                }
-            }
-        },
-        "ingress": {
-            "grpc": {"enabled": False},
-            "enabled": True,
-            "className": "traefik",
-            "hosts": [
+            "tolerations": [
                 {
-                    "host": f"{AppType.GptOss.value}--{APP_ID}.apps.some.org.neu.ro",
-                    "paths": [{"path": "/", "pathType": "Prefix", "portName": "http"}],
-                }
+                    "effect": "NoSchedule",
+                    "key": "platform.neuromation.io/job",
+                    "operator": "Exists",
+                },
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/not-ready",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300,
+                },
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/unreachable",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300,
+                },
+                {"effect": "NoSchedule", "key": "nvidia.com/gpu", "operator": "Exists"},
             ],
-        },
-        "podAnnotations": {
-            APOLO_STORAGE_LABEL: '[{"storage_uri": "storage://cluster/test-org/test-project/llm_bundles", "mount_path": "/root/.cache/huggingface", "mount_mode": "rw"}]'  # noqa: E501
-        },
-        "podExtraLabels": {
-            APOLO_STORAGE_LABEL: "true",
-            APOLO_ORG_LABEL: "test-org",
-            APOLO_PROJECT_LABEL: "test-project",
-        },
-        "modelDownload": {"hookEnabled": True, "initEnabled": False},
-        "cache": {"enabled": False},
-        "gpuProvider": "nvidia",
-        "nvidiaImage": {
-            "pullPolicy": "IfNotPresent",
-            "repository": "vllm/vllm-openai",
-            "tag": "v0.21.0"
-        },
-        "podLabels": {
-            "platform.apolo.us/component": "app",
-            "platform.apolo.us/preset": preset_name,
-        },
-        "apolo_app_id": APP_ID,
-        "envNvidia": {
-            "PATH": "/usr/local/cuda/bin:/usr/local/sbin:"
-            "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(PATH)",
-            "LD_LIBRARY_PATH": "/usr/local/cuda/lib64:"
-            "/usr/local/nvidia/lib64:$(LD_LIBRARY_PATH)",
-        },
-    }
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "platform.neuromation.io/nodepool",
+                                        "operator": "In",
+                                        "values": ["gpu_pool"],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "ingress": {
+                "grpc": {"enabled": False},
+                "enabled": True,
+                "className": "traefik",
+                "hosts": [
+                    {
+                        "host": f"{AppType.GptOss.value}--{APP_ID}.apps.some.org.neu.ro",  # noqa: E501
+                        "paths": [
+                            {"path": "/", "pathType": "Prefix", "portName": "http"}
+                        ],
+                    }
+                ],
+            },
+            "podAnnotations": {
+                APOLO_STORAGE_LABEL: '[{"storage_uri": "storage://cluster/test-org/test-project/llm_bundles", "mount_path": "/root/.cache/huggingface", "mount_mode": "rw"}]'  # noqa: E501
+            },
+            "podExtraLabels": {
+                APOLO_STORAGE_LABEL: "true",
+                APOLO_ORG_LABEL: "test-org",
+                APOLO_PROJECT_LABEL: "test-project",
+            },
+            "modelDownload": {"hookEnabled": True, "initEnabled": False},
+            "cache": {"enabled": False},
+            "gpuProvider": "nvidia",
+            "nvidiaImage": {
+                "pullPolicy": "IfNotPresent",
+                "repository": "vllm/vllm-openai",
+                "tag": "v0.21.0",
+            },
+            "podLabels": {
+                "platform.apolo.us/component": "app",
+                "platform.apolo.us/preset": preset_name,
+            },
+            "apolo_app_id": APP_ID,
+            "envNvidia": {
+                "PATH": "/usr/local/cuda/bin:/usr/local/sbin:"
+                "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(PATH)",
+                "LD_LIBRARY_PATH": "/usr/local/cuda/lib64:"
+                "/usr/local/nvidia/lib64:$(LD_LIBRARY_PATH)",
+            },
+        }
+    )

--- a/.apolo/tests/unit/bundles/test_gptoss_input_generation.py
+++ b/.apolo/tests/unit/bundles/test_gptoss_input_generation.py
@@ -122,6 +122,11 @@ async def test_values_llm_generation_gpu_default_preset(
         "modelDownload": {"hookEnabled": True, "initEnabled": False},
         "cache": {"enabled": False},
         "gpuProvider": "nvidia",
+        "nvidiaImage": {
+            "pullPolicy": "IfNotPresent",
+            "repository": "vllm/vllm-openai",
+            "tag": "v0.21.0"
+        },
         "podLabels": {
             "platform.apolo.us/component": "app",
             "platform.apolo.us/preset": preset_name,

--- a/.apolo/tests/unit/bundles/test_gpu_autoselection.py
+++ b/.apolo/tests/unit/bundles/test_gpu_autoselection.py
@@ -1,13 +1,11 @@
 from enum import StrEnum
 
 import pytest
-from apolo_app_types import HuggingFaceToken
+from apolo_app_types_fixtures.constants import TEST_PRESETS_WITH_EXTRA_LARGE_GPU
+from apolo_apps_llm_inference.app_types import LLMBundleInputs
 
 from apolo_app_types.helm.apps.bundles.llm import BaseLLMBundleMixin, ModelSettings
-from apolo_apps_llm_inference.app_types import LLMBundleInputs
 from apolo_app_types.protocols.common import ApoloSecret
-
-from apolo_app_types_fixtures.constants import TEST_PRESETS_WITH_EXTRA_LARGE_GPU
 
 
 class LLMSize(StrEnum):
@@ -63,10 +61,7 @@ async def test_get_preset__ok(
 ):
     apolo_client = setup_clients
     preset_name = await StubLLMBundleMixin(apolo_client)._get_preset(
-        LLMBundleInputs(
-            size=model_size,
-            hf_token=ApoloSecret(key="FakeSecret")
-        )
+        LLMBundleInputs(size=model_size, hf_token=ApoloSecret(key="FakeSecret"))
     )
     assert preset_name.name == expected_preset_name
 
@@ -80,8 +75,5 @@ async def test_get_preset__not_enough_vram(setup_clients, mock_get_preset_gpu):
     apolo_client = setup_clients
     with pytest.raises(RuntimeError):
         await StubLLMBundleMixin(apolo_client)._get_preset(
-            LLMBundleInputs(
-                size=LLMSize.size_e,
-                hf_token=ApoloSecret(key="FakeSecret")
-            )
+            LLMBundleInputs(size=LLMSize.size_e, hf_token=ApoloSecret(key="FakeSecret"))
         )

--- a/.apolo/tests/unit/bundles/test_kimi2_input_generation.py
+++ b/.apolo/tests/unit/bundles/test_kimi2_input_generation.py
@@ -1,27 +1,23 @@
-from apolo_app_types.app_types import AppType
-from apolo_app_types.helm.apps.common import (
-    APOLO_ORG_LABEL,
-    APOLO_PROJECT_LABEL,
-    APOLO_STORAGE_LABEL,
+import pytest
+from apolo_app_types_fixtures.constants import (
+    APP_ID,
+    APP_SECRETS_NAME,
+    DEFAULT_NAMESPACE,
 )
-from apolo_app_types.protocols.common import ApoloSecret
-
-from apolo_app_types_fixtures.constants import APP_ID, APP_SECRETS_NAME, DEFAULT_NAMESPACE
-
 from apolo_apps_llm_inference import Kimi2InferenceValueProcessor
 from apolo_apps_llm_inference.app_types import Kimi2Inputs, Kimi2Size
 
+from apolo_app_types.app_types import AppType
+from apolo_app_types.protocols.common import ApoloSecret
 
-async def test_values_kimi2_generation_gpu_default_preset(
-    setup_clients, mock_get_preset_gpu_h100
-):
+
+@pytest.mark.usefixtures("_mock_get_preset_gpu_h100")
+async def test_values_kimi2_generation_gpu_default_preset(setup_clients):
     """Test Kimi2 model generates correct helm values with H100 cluster preset."""
     model_to_test = Kimi2Size.k2_instruct
     preset_name = "h100-8x"
     apolo_client = setup_clients
-    input_processor = Kimi2InferenceValueProcessor(
-        client=apolo_client
-    )
+    input_processor = Kimi2InferenceValueProcessor(client=apolo_client)
     helm_params = await input_processor.gen_extra_values(
         input_=Kimi2Inputs(
             size=model_to_test,
@@ -42,16 +38,13 @@ async def test_values_kimi2_generation_gpu_default_preset(
     assert "--tensor-parallel-size=18" in helm_params["serverExtraArgs"]
 
 
-async def test_values_kimi2_thinking_model(
-    setup_clients, mock_get_preset_gpu_h100
-):
+@pytest.mark.usefixtures("_mock_get_preset_gpu_h100")
+async def test_values_kimi2_thinking_model(setup_clients):
     """Test Kimi2 Thinking model generates correct helm values."""
     model_to_test = Kimi2Size.k2_thinking
     preset_name = "h100-8x"
     apolo_client = setup_clients
-    input_processor = Kimi2InferenceValueProcessor(
-        client=apolo_client
-    )
+    input_processor = Kimi2InferenceValueProcessor(client=apolo_client)
     helm_params = await input_processor.gen_extra_values(
         input_=Kimi2Inputs(
             size=model_to_test,
@@ -71,16 +64,13 @@ async def test_values_kimi2_thinking_model(
     assert "--tensor-parallel-size=18" in helm_params["serverExtraArgs"]
 
 
-async def test_values_kimi2_base_model(
-    setup_clients, mock_get_preset_gpu_h100
-):
+@pytest.mark.usefixtures("_mock_get_preset_gpu_h100")
+async def test_values_kimi2_base_model(setup_clients):
     """Test Kimi2 Base model generates correct helm values."""
     model_to_test = Kimi2Size.k2_base
     preset_name = "h100-8x"
     apolo_client = setup_clients
-    input_processor = Kimi2InferenceValueProcessor(
-        client=apolo_client
-    )
+    input_processor = Kimi2InferenceValueProcessor(client=apolo_client)
     helm_params = await input_processor.gen_extra_values(
         input_=Kimi2Inputs(
             size=model_to_test,
@@ -99,16 +89,13 @@ async def test_values_kimi2_base_model(
     assert helm_params["gpuProvider"] == "nvidia"
 
 
-async def test_values_kimi2_instruct_0905_model(
-    setup_clients, mock_get_preset_gpu_h100
-):
+@pytest.mark.usefixtures("_mock_get_preset_gpu_h100")
+async def test_values_kimi2_instruct_0905_model(setup_clients):
     """Test Kimi2 Instruct 0905 model generates correct helm values."""
     model_to_test = Kimi2Size.k2_instruct_0905
     preset_name = "h100-8x"
     apolo_client = setup_clients
-    input_processor = Kimi2InferenceValueProcessor(
-        client=apolo_client
-    )
+    input_processor = Kimi2InferenceValueProcessor(client=apolo_client)
     helm_params = await input_processor.gen_extra_values(
         input_=Kimi2Inputs(
             size=model_to_test,
@@ -130,16 +117,13 @@ async def test_values_kimi2_instruct_0905_model(
 # GGUF Quantized Model Tests
 
 
-async def test_values_kimi2_gguf_q2_k_xl(
-    setup_clients, mock_get_preset_gpu_gguf
-):
+@pytest.mark.usefixtures("_mock_get_preset_gpu_gguf")
+async def test_values_kimi2_gguf_q2_k_xl(setup_clients):
     """Test Kimi2 Q2_K_XL quantized model (400GB VRAM requirement)."""
     model_to_test = Kimi2Size.k2_instruct_q2_k_xl
     preset_name = "h100-6x"  # 6x80GB = 480GB, fits 400GB requirement
     apolo_client = setup_clients
-    input_processor = Kimi2InferenceValueProcessor(
-        client=apolo_client
-    )
+    input_processor = Kimi2InferenceValueProcessor(client=apolo_client)
     helm_params = await input_processor.gen_extra_values(
         input_=Kimi2Inputs(
             size=model_to_test,
@@ -159,16 +143,13 @@ async def test_values_kimi2_gguf_q2_k_xl(
     assert "--tensor-parallel-size=6" in helm_params["serverExtraArgs"]
 
 
-async def test_values_kimi2_gguf_q4_k_xl(
-    setup_clients, mock_get_preset_gpu_gguf
-):
+@pytest.mark.usefixtures("_mock_get_preset_gpu_gguf")
+async def test_values_kimi2_gguf_q4_k_xl(setup_clients):
     """Test Kimi2 Q4_K_XL quantized model (600GB VRAM requirement)."""
     model_to_test = Kimi2Size.k2_instruct_q4_k_xl
     preset_name = "h100-8x"  # 8x80GB = 640GB, fits 600GB requirement
     apolo_client = setup_clients
-    input_processor = Kimi2InferenceValueProcessor(
-        client=apolo_client
-    )
+    input_processor = Kimi2InferenceValueProcessor(client=apolo_client)
     helm_params = await input_processor.gen_extra_values(
         input_=Kimi2Inputs(
             size=model_to_test,
@@ -188,16 +169,13 @@ async def test_values_kimi2_gguf_q4_k_xl(
     assert "--tensor-parallel-size=8" in helm_params["serverExtraArgs"]
 
 
-async def test_values_kimi2_gguf_q8_0(
-    setup_clients, mock_get_preset_gpu_gguf
-):
+@pytest.mark.usefixtures("_mock_get_preset_gpu_gguf")
+async def test_values_kimi2_gguf_q8_0(setup_clients):
     """Test Kimi2 Q8_0 quantized model (1100GB VRAM requirement)."""
     model_to_test = Kimi2Size.k2_instruct_q8_0
     preset_name = "h100-14x"  # 14x80GB = 1120GB, fits 1100GB requirement
     apolo_client = setup_clients
-    input_processor = Kimi2InferenceValueProcessor(
-        client=apolo_client
-    )
+    input_processor = Kimi2InferenceValueProcessor(client=apolo_client)
     helm_params = await input_processor.gen_extra_values(
         input_=Kimi2Inputs(
             size=model_to_test,

--- a/.apolo/tests/unit/bundles/test_llama4_input_generation.py
+++ b/.apolo/tests/unit/bundles/test_llama4_input_generation.py
@@ -1,6 +1,14 @@
 import pytest
+from apolo_app_types_fixtures.constants import (
+    APP_ID,
+    APP_SECRETS_NAME,
+    CPU_PRESETS,
+    DEFAULT_NAMESPACE,
+    TEST_PRESETS_WITH_EXTRA_LARGE_GPU,
+)
+from apolo_apps_llm_inference import Llama4InferenceValueProcessor
+from apolo_apps_llm_inference.app_types import LLama4Inputs, Llama4Size
 
-from apolo_app_types import HuggingFaceToken
 from apolo_app_types.app_types import AppType
 from apolo_app_types.helm.apps.bundles.llm import Llama4ValueProcessor
 from apolo_app_types.helm.apps.common import (
@@ -10,13 +18,6 @@ from apolo_app_types.helm.apps.common import (
 )
 from apolo_app_types.protocols.common import ApoloSecret
 
-from apolo_app_types_fixtures.constants import (
-    APP_ID, APP_SECRETS_NAME, DEFAULT_NAMESPACE, CPU_PRESETS, TEST_PRESETS_WITH_EXTRA_LARGE_GPU
-)
-
-from apolo_apps_llm_inference import Llama4InferenceValueProcessor
-from apolo_apps_llm_inference.app_types import LLama4Inputs, Llama4Size
-
 
 @pytest.mark.parametrize("presets_available", [CPU_PRESETS], indirect=True)
 async def test_values_llm_generation_gpu_default_preset(
@@ -24,11 +25,9 @@ async def test_values_llm_generation_gpu_default_preset(
 ):
     model_to_test = Llama4Size.scout
     apolo_client = setup_clients
+    input_processor = Llama4InferenceValueProcessor(client=apolo_client)
     with pytest.raises(RuntimeError) as err:
-        input_processor = Llama4InferenceValueProcessor(
-            client=apolo_client
-        )
-        helm_params = await input_processor.gen_extra_values(
+        _ = await input_processor.gen_extra_values(
             input_=LLama4Inputs(
                 size=model_to_test,
                 hf_token=ApoloSecret(key="FakeSecret"),
@@ -51,9 +50,7 @@ async def test_values_llm_generation_gpu_big_model(setup_clients, mock_get_prese
     model_to_test = Llama4Size.scout
     preset_name = "a100-large"
     apolo_client = setup_clients
-    input_processor = Llama4InferenceValueProcessor(
-        client=apolo_client
-    )
+    input_processor = Llama4InferenceValueProcessor(client=apolo_client)
     helm_params = await input_processor.gen_extra_values(
         input_=LLama4Inputs(
             size=model_to_test,
@@ -67,105 +64,114 @@ async def test_values_llm_generation_gpu_big_model(setup_clients, mock_get_prese
         app_id=APP_ID,
     )
 
-    assert helm_params == {
-        "serverExtraArgs": [],
-        "model": {
-            "modelHFName": Llama4ValueProcessor.model_map[model_to_test].model_hf_name,
-            "tokenizerHFName": Llama4ValueProcessor.model_map[
-                model_to_test
-            ].model_hf_name,
-        },
-        "llm": {
-            "modelHFName": Llama4ValueProcessor.model_map[model_to_test].model_hf_name,
-            "tokenizerHFName": Llama4ValueProcessor.model_map[
-                model_to_test
-            ].model_hf_name,
-        },
-        "env": {
-            "HUGGING_FACE_HUB_TOKEN": {
-                "valueFrom": {
-                    "secretKeyRef": {"name": "apps-secrets", "key": "FakeSecret"}
+    assert (
+        helm_params
+        == {
+            "serverExtraArgs": [],
+            "model": {
+                "modelHFName": Llama4ValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+                "tokenizerHFName": Llama4ValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+            },
+            "llm": {
+                "modelHFName": Llama4ValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+                "tokenizerHFName": Llama4ValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+            },
+            "env": {
+                "HUGGING_FACE_HUB_TOKEN": {
+                    "valueFrom": {
+                        "secretKeyRef": {"name": "apps-secrets", "key": "FakeSecret"}
+                    }
                 }
-            }
-        },
-        "preset_name": preset_name,
-        "resources": {
-            "requests": {"cpu": "8000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
-            "limits": {"cpu": "8000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
-        },
-        "tolerations": [
-            {
-                "effect": "NoSchedule",
-                "key": "platform.neuromation.io/job",
-                "operator": "Exists",
             },
-            {
-                "effect": "NoExecute",
-                "key": "node.kubernetes.io/not-ready",
-                "operator": "Exists",
-                "tolerationSeconds": 300,
+            "preset_name": preset_name,
+            "resources": {
+                "requests": {"cpu": "8000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
+                "limits": {"cpu": "8000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
             },
-            {
-                "effect": "NoExecute",
-                "key": "node.kubernetes.io/unreachable",
-                "operator": "Exists",
-                "tolerationSeconds": 300,
-            },
-            {"effect": "NoSchedule", "key": "nvidia.com/gpu", "operator": "Exists"},
-        ],
-        "affinity": {
-            "nodeAffinity": {
-                "requiredDuringSchedulingIgnoredDuringExecution": {
-                    "nodeSelectorTerms": [
-                        {
-                            "matchExpressions": [
-                                {
-                                    "key": "platform.neuromation.io/nodepool",
-                                    "operator": "In",
-                                    "values": ["gpu_pool"],
-                                }
-                            ]
-                        }
-                    ]
-                }
-            }
-        },
-        "ingress": {
-            "grpc": {"enabled": False},
-            "enabled": True,
-            "className": "traefik",
-            "hosts": [
+            "tolerations": [
                 {
-                    "host": f"{AppType.Llama4.value}--{APP_ID}.apps.some.org.neu.ro",
-                    "paths": [{"path": "/", "pathType": "Prefix", "portName": "http"}],
-                }
+                    "effect": "NoSchedule",
+                    "key": "platform.neuromation.io/job",
+                    "operator": "Exists",
+                },
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/not-ready",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300,
+                },
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/unreachable",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300,
+                },
+                {"effect": "NoSchedule", "key": "nvidia.com/gpu", "operator": "Exists"},
             ],
-        },
-        "podAnnotations": {
-            APOLO_STORAGE_LABEL: '[{"storage_uri": "storage://cluster/test-org/test-project/llm_bundles", "mount_path": "/root/.cache/huggingface", "mount_mode": "rw"}]'  # noqa: E501
-        },
-        "podExtraLabels": {
-            APOLO_STORAGE_LABEL: "true",
-            APOLO_ORG_LABEL: "test-org",
-            APOLO_PROJECT_LABEL: "test-project",
-        },
-        "modelDownload": {"hookEnabled": True, "initEnabled": False},
-        "cache": {"enabled": False},
-        "gpuProvider": "nvidia",
-        "nvidiaImage": {
-            "pullPolicy": "IfNotPresent",
-            "repository": "vllm/vllm-openai",
-            "tag": "v0.21.0"
-        },
-        "podLabels": {
-            "platform.apolo.us/component": "app",
-            "platform.apolo.us/preset": preset_name,
-        },
-        "apolo_app_id": APP_ID,
-        "envNvidia": {
-            "PATH": "/usr/local/cuda/bin:/usr/local/sbin:"
-            "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(PATH)",
-            "LD_LIBRARY_PATH": "/usr/local/cuda/lib64:"
-            "/usr/local/nvidia/lib64:$(LD_LIBRARY_PATH)",
-        },
-    }
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "platform.neuromation.io/nodepool",
+                                        "operator": "In",
+                                        "values": ["gpu_pool"],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "ingress": {
+                "grpc": {"enabled": False},
+                "enabled": True,
+                "className": "traefik",
+                "hosts": [
+                    {
+                        "host": f"{AppType.Llama4.value}--{APP_ID}.apps.some.org.neu.ro",  # noqa: E501
+                        "paths": [
+                            {"path": "/", "pathType": "Prefix", "portName": "http"}
+                        ],
+                    }
+                ],
+            },
+            "podAnnotations": {
+                APOLO_STORAGE_LABEL: '[{"storage_uri": "storage://cluster/test-org/test-project/llm_bundles", "mount_path": "/root/.cache/huggingface", "mount_mode": "rw"}]'  # noqa: E501
+            },
+            "podExtraLabels": {
+                APOLO_STORAGE_LABEL: "true",
+                APOLO_ORG_LABEL: "test-org",
+                APOLO_PROJECT_LABEL: "test-project",
+            },
+            "modelDownload": {"hookEnabled": True, "initEnabled": False},
+            "cache": {"enabled": False},
+            "gpuProvider": "nvidia",
+            "nvidiaImage": {
+                "pullPolicy": "IfNotPresent",
+                "repository": "vllm/vllm-openai",
+                "tag": "v0.21.0",
+            },
+            "podLabels": {
+                "platform.apolo.us/component": "app",
+                "platform.apolo.us/preset": preset_name,
+            },
+            "apolo_app_id": APP_ID,
+            "envNvidia": {
+                "PATH": "/usr/local/cuda/bin:/usr/local/sbin:"
+                "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(PATH)",
+                "LD_LIBRARY_PATH": "/usr/local/cuda/lib64:"
+                "/usr/local/nvidia/lib64:$(LD_LIBRARY_PATH)",
+            },
+        }
+    )

--- a/.apolo/tests/unit/bundles/test_llama4_input_generation.py
+++ b/.apolo/tests/unit/bundles/test_llama4_input_generation.py
@@ -152,6 +152,11 @@ async def test_values_llm_generation_gpu_big_model(setup_clients, mock_get_prese
         "modelDownload": {"hookEnabled": True, "initEnabled": False},
         "cache": {"enabled": False},
         "gpuProvider": "nvidia",
+        "nvidiaImage": {
+            "pullPolicy": "IfNotPresent",
+            "repository": "vllm/vllm-openai",
+            "tag": "v0.21.0"
+        },
         "podLabels": {
             "platform.apolo.us/component": "app",
             "platform.apolo.us/preset": preset_name,

--- a/.apolo/tests/unit/bundles/test_mistral_input_generation.py
+++ b/.apolo/tests/unit/bundles/test_mistral_input_generation.py
@@ -1,16 +1,18 @@
+from apolo_app_types_fixtures.constants import (
+    APP_ID,
+    APP_SECRETS_NAME,
+    DEFAULT_NAMESPACE,
+)
+from apolo_apps_llm_inference import MistralInferenceValueProcessor
+from apolo_apps_llm_inference.app_types import MistralInputs, MistralSize
+
 from apolo_app_types.app_types import AppType
 from apolo_app_types.helm.apps.common import (
     APOLO_ORG_LABEL,
     APOLO_PROJECT_LABEL,
     APOLO_STORAGE_LABEL,
 )
-
 from apolo_app_types.protocols.common import ApoloSecret
-
-from apolo_app_types_fixtures.constants import APP_ID, APP_SECRETS_NAME, DEFAULT_NAMESPACE
-
-from apolo_apps_llm_inference import MistralInferenceValueProcessor
-from apolo_apps_llm_inference.app_types import MistralInputs, MistralSize
 
 
 async def test_values_mistral_generation_gpu_default_preset(
@@ -19,9 +21,7 @@ async def test_values_mistral_generation_gpu_default_preset(
     model_to_test = MistralSize.mistral_7b_v02
     preset_name = "t4-medium"
     apolo_client = setup_clients
-    input_processor = MistralInferenceValueProcessor(
-        client=apolo_client
-    )
+    input_processor = MistralInferenceValueProcessor(client=apolo_client)
     helm_params = await input_processor.gen_extra_values(
         input_=MistralInputs(
             size=model_to_test,
@@ -35,105 +35,114 @@ async def test_values_mistral_generation_gpu_default_preset(
         app_id=APP_ID,
     )
 
-    assert helm_params == {
-        "serverExtraArgs": [],
-        "model": {
-            "modelHFName": MistralInferenceValueProcessor.model_map[model_to_test].model_hf_name,
-            "tokenizerHFName": MistralInferenceValueProcessor.model_map[
-                model_to_test
-            ].model_hf_name,
-        },
-        "llm": {
-            "modelHFName": MistralInferenceValueProcessor.model_map[model_to_test].model_hf_name,
-            "tokenizerHFName": MistralInferenceValueProcessor.model_map[
-                model_to_test
-            ].model_hf_name,
-        },
-        "env": {
-            "HUGGING_FACE_HUB_TOKEN": {
-                "valueFrom": {
-                    "secretKeyRef": {"name": "apps-secrets", "key": "FakeSecret"}
+    assert (
+        helm_params
+        == {
+            "serverExtraArgs": [],
+            "model": {
+                "modelHFName": MistralInferenceValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+                "tokenizerHFName": MistralInferenceValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+            },
+            "llm": {
+                "modelHFName": MistralInferenceValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+                "tokenizerHFName": MistralInferenceValueProcessor.model_map[
+                    model_to_test
+                ].model_hf_name,
+            },
+            "env": {
+                "HUGGING_FACE_HUB_TOKEN": {
+                    "valueFrom": {
+                        "secretKeyRef": {"name": "apps-secrets", "key": "FakeSecret"}
+                    }
                 }
-            }
-        },
-        "preset_name": preset_name,
-        "resources": {
-            "requests": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
-            "limits": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
-        },
-        "tolerations": [
-            {
-                "effect": "NoSchedule",
-                "key": "platform.neuromation.io/job",
-                "operator": "Exists",
             },
-            {
-                "effect": "NoExecute",
-                "key": "node.kubernetes.io/not-ready",
-                "operator": "Exists",
-                "tolerationSeconds": 300,
+            "preset_name": preset_name,
+            "resources": {
+                "requests": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
+                "limits": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
             },
-            {
-                "effect": "NoExecute",
-                "key": "node.kubernetes.io/unreachable",
-                "operator": "Exists",
-                "tolerationSeconds": 300,
-            },
-            {"effect": "NoSchedule", "key": "nvidia.com/gpu", "operator": "Exists"},
-        ],
-        "affinity": {
-            "nodeAffinity": {
-                "requiredDuringSchedulingIgnoredDuringExecution": {
-                    "nodeSelectorTerms": [
-                        {
-                            "matchExpressions": [
-                                {
-                                    "key": "platform.neuromation.io/nodepool",
-                                    "operator": "In",
-                                    "values": ["gpu_pool"],
-                                }
-                            ]
-                        }
-                    ]
-                }
-            }
-        },
-        "ingress": {
-            "grpc": {"enabled": False},
-            "enabled": True,
-            "className": "traefik",
-            "hosts": [
+            "tolerations": [
                 {
-                    "host": f"{AppType.Mistral.value}--{APP_ID}.apps.some.org.neu.ro",
-                    "paths": [{"path": "/", "pathType": "Prefix", "portName": "http"}],
-                }
+                    "effect": "NoSchedule",
+                    "key": "platform.neuromation.io/job",
+                    "operator": "Exists",
+                },
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/not-ready",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300,
+                },
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/unreachable",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300,
+                },
+                {"effect": "NoSchedule", "key": "nvidia.com/gpu", "operator": "Exists"},
             ],
-        },
-        "podAnnotations": {
-            APOLO_STORAGE_LABEL: '[{"storage_uri": "storage://cluster/test-org/test-project/llm_bundles", "mount_path": "/root/.cache/huggingface", "mount_mode": "rw"}]'  # noqa: E501
-        },
-        "podExtraLabels": {
-            APOLO_STORAGE_LABEL: "true",
-            APOLO_ORG_LABEL: "test-org",
-            APOLO_PROJECT_LABEL: "test-project",
-        },
-        "modelDownload": {"hookEnabled": True, "initEnabled": False},
-        "cache": {"enabled": False},
-        "gpuProvider": "nvidia",
-        "nvidiaImage": {
-            "pullPolicy": "IfNotPresent",
-            "repository": "vllm/vllm-openai",
-            "tag": "v0.21.0"
-        },
-        "podLabels": {
-            "platform.apolo.us/component": "app",
-            "platform.apolo.us/preset": preset_name,
-        },
-        "apolo_app_id": APP_ID,
-        "envNvidia": {
-            "PATH": "/usr/local/cuda/bin:/usr/local/sbin:"
-            "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(PATH)",
-            "LD_LIBRARY_PATH": "/usr/local/cuda/lib64:"
-            "/usr/local/nvidia/lib64:$(LD_LIBRARY_PATH)",
-        },
-    }
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "platform.neuromation.io/nodepool",
+                                        "operator": "In",
+                                        "values": ["gpu_pool"],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "ingress": {
+                "grpc": {"enabled": False},
+                "enabled": True,
+                "className": "traefik",
+                "hosts": [
+                    {
+                        "host": f"{AppType.Mistral.value}--{APP_ID}.apps.some.org.neu.ro",  # noqa: E501
+                        "paths": [
+                            {"path": "/", "pathType": "Prefix", "portName": "http"}
+                        ],
+                    }
+                ],
+            },
+            "podAnnotations": {
+                APOLO_STORAGE_LABEL: '[{"storage_uri": "storage://cluster/test-org/test-project/llm_bundles", "mount_path": "/root/.cache/huggingface", "mount_mode": "rw"}]'  # noqa: E501
+            },
+            "podExtraLabels": {
+                APOLO_STORAGE_LABEL: "true",
+                APOLO_ORG_LABEL: "test-org",
+                APOLO_PROJECT_LABEL: "test-project",
+            },
+            "modelDownload": {"hookEnabled": True, "initEnabled": False},
+            "cache": {"enabled": False},
+            "gpuProvider": "nvidia",
+            "nvidiaImage": {
+                "pullPolicy": "IfNotPresent",
+                "repository": "vllm/vllm-openai",
+                "tag": "v0.21.0",
+            },
+            "podLabels": {
+                "platform.apolo.us/component": "app",
+                "platform.apolo.us/preset": preset_name,
+            },
+            "apolo_app_id": APP_ID,
+            "envNvidia": {
+                "PATH": "/usr/local/cuda/bin:/usr/local/sbin:"
+                "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(PATH)",
+                "LD_LIBRARY_PATH": "/usr/local/cuda/lib64:"
+                "/usr/local/nvidia/lib64:$(LD_LIBRARY_PATH)",
+            },
+        }
+    )

--- a/.apolo/tests/unit/bundles/test_mistral_input_generation.py
+++ b/.apolo/tests/unit/bundles/test_mistral_input_generation.py
@@ -120,6 +120,11 @@ async def test_values_mistral_generation_gpu_default_preset(
         "modelDownload": {"hookEnabled": True, "initEnabled": False},
         "cache": {"enabled": False},
         "gpuProvider": "nvidia",
+        "nvidiaImage": {
+            "pullPolicy": "IfNotPresent",
+            "repository": "vllm/vllm-openai",
+            "tag": "v0.21.0"
+        },
         "podLabels": {
             "platform.apolo.us/component": "app",
             "platform.apolo.us/preset": preset_name,

--- a/.apolo/tests/unit/constants.py
+++ b/.apolo/tests/unit/constants.py
@@ -98,23 +98,3 @@ TEST_PRESETS_WITH_H100_CLUSTER = {
         available_resource_pool_names=("gpu_pool",),
     ),
 }
-
-
-# OpenWebUI Test Constants
-DEFAULT_AUTH_MIDDLEWARE = "platform-platform-control-plane-ingress-auth"
-CUSTOM_AUTH_MIDDLEWARE = "platform-custom-auth-middleware"
-CUSTOM_RATE_LIMITING_MIDDLEWARE = "platform-custom-rate-limiting-middleware"
-
-DATABASE_SQLITE = "sqlite"
-DATABASE_POSTGRES = "postgres"
-
-# Default PostgreSQL credentials for testing
-DEFAULT_POSTGRES_CREDS = CrunchyPostgresUserCredentials(
-    user="pgvector_user",
-    password="pgvector_password",
-    host="pgvector_host",
-    port=5432,
-    pgbouncer_host="pgbouncer_host",
-    pgbouncer_port=4321,
-    dbname="db_name",
-)

--- a/.apolo/tests/unit/constants.py
+++ b/.apolo/tests/unit/constants.py
@@ -3,8 +3,6 @@ from decimal import Decimal
 from apolo_sdk import Preset
 from neuro_config_client import NvidiaGPUPreset
 
-from apolo_app_types import CrunchyPostgresUserCredentials
-
 
 CPU_POOL = "cpu_pool"
 GPU_POOL = "gpu_pool"

--- a/.apolo/tests/unit/llm/test_input_generation.py
+++ b/.apolo/tests/unit/llm/test_input_generation.py
@@ -13,7 +13,7 @@ from apolo_app_types.protocols.common.autoscaling import (
     AutoscalingKedaHTTP,
     RequestRateConfig,
 )
-from apolo_app_types.protocols.common.hugging_face import HuggingFaceModelDetailDynamic
+from apolo_app_types.protocols.common.hugging_face import HuggingFaceModelDetailDynamic, HuggingFaceModel
 from apolo_app_types.protocols.common.secrets_ import ApoloSecret
 
 from apolo_app_types_fixtures.constants import APP_ID, APP_SECRETS_NAME, CPU_POOL, DEFAULT_NAMESPACE
@@ -755,3 +755,73 @@ async def test_values_llm_generation_with_cached_dynamic_model(
     # Storage integration should still be configured for mounting the cached model
     assert APOLO_STORAGE_LABEL in helm_params["podExtraLabels"]
     assert APOLO_STORAGE_LABEL in helm_params["podAnnotations"]
+
+
+async def test_values_llm_generation_with_hf_model_no_cache_no_token(
+    setup_clients, mock_get_preset_gpu
+):
+    apolo_client = setup_clients
+    input_processor = VLLMInferenceInputsProcessor(client=apolo_client)
+
+    helm_params = await input_processor.gen_extra_values(
+        input_=VLLMInferenceInputs(
+            preset=Preset(name="gpu-small"),
+            ingress_http=IngressHttp(),
+            hugging_face_model=HuggingFaceModel(
+                model_hf_name="meta-llama/Llama-2-7b-hf",
+            ),
+        ),
+        app_type=AppType.LLMInference,
+        app_name="llm",
+        namespace=DEFAULT_NAMESPACE,
+        app_secrets_name=APP_SECRETS_NAME,
+        app_id=APP_ID,
+    )
+
+    assert helm_params["model"]["modelHFName"] == "meta-llama/Llama-2-7b-hf"
+    assert helm_params["modelDownload"]["hookEnabled"] is False
+    assert helm_params["modelDownload"]["initEnabled"] is True
+    assert helm_params["cache"]["enabled"] is True
+
+    # No storage integration labels without cache
+    assert helm_params["podExtraLabels"] == {}
+
+async def test_values_llm_generation_with_hf_model_no_cache_token(
+    setup_clients, mock_get_preset_gpu
+):
+    apolo_client = setup_clients
+    input_processor = VLLMInferenceInputsProcessor(client=apolo_client)
+
+    dynamic_model = HuggingFaceModel(
+        model_hf_name="meta-llama/Llama-2-7b-hf",
+        hf_token=HuggingFaceToken(
+            token_name="mytoken",
+            token=ApoloSecret(
+                key="sec",
+            )
+        ),
+    )
+
+    helm_params = await input_processor.gen_extra_values(
+        input_=VLLMInferenceInputs(
+            preset=Preset(name="gpu-small"),
+            ingress_http=IngressHttp(),
+            hugging_face_model=dynamic_model,
+        ),
+        app_type=AppType.LLMInference,
+        app_name="llm",
+        namespace=DEFAULT_NAMESPACE,
+        app_secrets_name=APP_SECRETS_NAME,
+        app_id=APP_ID,
+    )
+
+    # Verify model name is extracted correctly
+    assert helm_params["model"]["modelHFName"] == "meta-llama/Llama-2-7b-hf"
+
+    # Without cache, init container should be used
+    assert helm_params["modelDownload"]["hookEnabled"] is False
+    assert helm_params["modelDownload"]["initEnabled"] is True
+    assert helm_params["cache"]["enabled"] is True
+
+    # No storage integration labels without cache
+    assert helm_params["podExtraLabels"] == {}

--- a/.apolo/tests/unit/llm/test_input_generation.py
+++ b/.apolo/tests/unit/llm/test_input_generation.py
@@ -205,6 +205,11 @@ async def test_values_llm_generation_gpu(setup_clients, mock_get_preset_gpu):
         "modelDownload": {"hookEnabled": False, "initEnabled": True},
         "cache": {"enabled": True},
         "gpuProvider": "nvidia",
+        "nvidiaImage": {
+            "pullPolicy": "IfNotPresent",
+            "repository": "vllm/vllm-openai",
+            "tag": "v0.21.0"
+        },
         "podLabels": {
             "platform.apolo.us/component": "app",
             "platform.apolo.us/preset": "gpu-small",
@@ -552,6 +557,11 @@ async def test_values_llm_generation__storage_integrated(
         },
         "modelDownload": {"hookEnabled": True, "initEnabled": False},
         "cache": {"enabled": False},
+        "nvidiaImage": {
+            "pullPolicy": "IfNotPresent",
+            "repository": "vllm/vllm-openai",
+            "tag": "v0.21.0"
+        },
         "gpuProvider": "nvidia",
         "podLabels": {
             "platform.apolo.us/component": "app",

--- a/.apolo/tests/unit/llm/test_input_generation.py
+++ b/.apolo/tests/unit/llm/test_input_generation.py
@@ -1,5 +1,13 @@
-from apolo_app_types import HuggingFaceToken
+from apolo_app_types_fixtures.constants import (
+    APP_ID,
+    APP_SECRETS_NAME,
+    CPU_POOL,
+    DEFAULT_NAMESPACE,
+)
 from apolo_apps_llm_inference import VLLMInferenceInputs
+from apolo_apps_llm_inference.inputs_processor import VLLMInferenceInputsProcessor
+
+from apolo_app_types import HuggingFaceToken
 from apolo_app_types.app_types import AppType
 from apolo_app_types.helm.apps.common import (
     APOLO_ORG_LABEL,
@@ -8,23 +16,28 @@ from apolo_app_types.helm.apps.common import (
     _get_match_expressions,
 )
 from apolo_app_types.helm.apps.llm import KEDA_HTTP_PROXY_SERVICE
-from apolo_app_types.protocols.common import ApoloFilesPath, IngressHttp, Preset, ApoloAuth
+from apolo_app_types.protocols.common import (
+    ApoloAuth,
+    ApoloFilesPath,
+    IngressHttp,
+    Preset,
+)
 from apolo_app_types.protocols.common.autoscaling import (
     AutoscalingKedaHTTP,
     RequestRateConfig,
 )
-from apolo_app_types.protocols.common.hugging_face import HuggingFaceModelDetailDynamic, HuggingFaceModel
+from apolo_app_types.protocols.common.hugging_face import (
+    HuggingFaceCache,
+    HuggingFaceModel,
+    HuggingFaceModelDetailDynamic,
+)
 from apolo_app_types.protocols.common.secrets_ import ApoloSecret
 
-from apolo_app_types_fixtures.constants import APP_ID, APP_SECRETS_NAME, CPU_POOL, DEFAULT_NAMESPACE
-from apolo_apps_llm_inference.inputs_processor import VLLMInferenceInputsProcessor
 
 async def test_values_llm_generation_cpu(setup_clients, mock_get_preset_cpu):
     hf_token = "test3"
     apolo_client = setup_clients
-    input_processor = VLLMInferenceInputsProcessor(
-        client=apolo_client
-    )
+    input_processor = VLLMInferenceInputsProcessor(client=apolo_client)
 
     helm_params = await input_processor.gen_extra_values(
         input_=VLLMInferenceInputs(
@@ -37,8 +50,7 @@ async def test_values_llm_generation_cpu(setup_clients, mock_get_preset_cpu):
                 name="test",
                 visibility="public",
                 hf_token=HuggingFaceToken(
-                    token_name="token1",
-                    token=ApoloSecret(key=hf_token)
+                    token_name="token1", token=ApoloSecret(key=hf_token)
                 ),
             ),
             tokenizer_hf_name="test_tokenizer",
@@ -103,9 +115,7 @@ async def test_values_llm_generation_cpu(setup_clients, mock_get_preset_cpu):
 async def test_values_llm_generation_gpu(setup_clients, mock_get_preset_gpu):
     hf_token = "test3"
     apolo_client = setup_clients
-    input_processor = VLLMInferenceInputsProcessor(
-        client=apolo_client
-    )
+    input_processor = VLLMInferenceInputsProcessor(client=apolo_client)
 
     helm_params = await input_processor.gen_extra_values(
         input_=VLLMInferenceInputs(
@@ -118,8 +128,7 @@ async def test_values_llm_generation_gpu(setup_clients, mock_get_preset_gpu):
                 name="test",
                 visibility="public",
                 hf_token=HuggingFaceToken(
-                    token_name="token1",
-                    token=ApoloSecret(key=hf_token)
+                    token_name="token1", token=ApoloSecret(key=hf_token)
                 ),
             ),
             tokenizer_hf_name="test_tokenizer",
@@ -208,7 +217,7 @@ async def test_values_llm_generation_gpu(setup_clients, mock_get_preset_gpu):
         "nvidiaImage": {
             "pullPolicy": "IfNotPresent",
             "repository": "vllm/vllm-openai",
-            "tag": "v0.21.0"
+            "tag": "v0.21.0",
         },
         "podLabels": {
             "platform.apolo.us/component": "app",
@@ -228,9 +237,7 @@ async def test_values_llm_generation_cpu_apolo_secret(
     setup_clients, mock_get_preset_cpu
 ):
     apolo_client = setup_clients
-    input_processor = VLLMInferenceInputsProcessor(
-        client=apolo_client
-    )
+    input_processor = VLLMInferenceInputsProcessor(client=apolo_client)
 
     helm_params = await input_processor.gen_extra_values(
         input_=VLLMInferenceInputs(
@@ -243,8 +250,7 @@ async def test_values_llm_generation_cpu_apolo_secret(
                 name="test",
                 visibility="public",
                 hf_token=HuggingFaceToken(
-                    token_name="token1",
-                    token=ApoloSecret(key='hf_token')
+                    token_name="token1", token=ApoloSecret(key="hf_token")
                 ),
             ),
             tokenizer_hf_name="test_tokenizer",
@@ -309,9 +315,7 @@ async def test_values_llm_generation_cpu_apolo_secret(
 
 async def test_values_llm_generation_gpu_4x(setup_clients, mock_get_preset_gpu):
     apolo_client = setup_clients
-    input_processor = VLLMInferenceInputsProcessor(
-        client=apolo_client
-    )
+    input_processor = VLLMInferenceInputsProcessor(client=apolo_client)
 
     helm_params = await input_processor.gen_extra_values(
         input_=VLLMInferenceInputs(
@@ -322,8 +326,7 @@ async def test_values_llm_generation_gpu_4x(setup_clients, mock_get_preset_gpu):
                 name="test",
                 visibility="public",
                 hf_token=HuggingFaceToken(
-                    token_name="token1",
-                    token=ApoloSecret(key='hf_token')
+                    token_name="token1", token=ApoloSecret(key="hf_token")
                 ),
             ),
             server_extra_args=["--foo"],
@@ -340,9 +343,7 @@ async def test_values_llm_generation_gpu_4x(setup_clients, mock_get_preset_gpu):
 
 async def test_values_llm_generation_gpu_8x(setup_clients, mock_get_preset_gpu):
     apolo_client = setup_clients
-    input_processor = VLLMInferenceInputsProcessor(
-        client=apolo_client
-    )
+    input_processor = VLLMInferenceInputsProcessor(client=apolo_client)
 
     helm_params = await input_processor.gen_extra_values(
         input_=VLLMInferenceInputs(
@@ -353,8 +354,7 @@ async def test_values_llm_generation_gpu_8x(setup_clients, mock_get_preset_gpu):
                 name="test",
                 visibility="public",
                 hf_token=HuggingFaceToken(
-                    token_name="token1",
-                    token=ApoloSecret(key='hf_token')
+                    token_name="token1", token=ApoloSecret(key="hf_token")
                 ),
             ),
             server_extra_args=["--bar"],
@@ -372,9 +372,7 @@ async def test_values_llm_generation_gpu_8x(setup_clients, mock_get_preset_gpu):
 
 async def test_values_llm_generation_gpu_8x_pps(setup_clients, mock_get_preset_gpu):
     apolo_client = setup_clients
-    input_processor = VLLMInferenceInputsProcessor(
-        client=apolo_client
-    )
+    input_processor = VLLMInferenceInputsProcessor(client=apolo_client)
 
     helm_params = await input_processor.gen_extra_values(
         input_=VLLMInferenceInputs(
@@ -385,8 +383,7 @@ async def test_values_llm_generation_gpu_8x_pps(setup_clients, mock_get_preset_g
                 name="test",
                 visibility="public",
                 hf_token=HuggingFaceToken(
-                    token_name="token1",
-                    token=ApoloSecret(key='hf_token')
+                    token_name="token1", token=ApoloSecret(key="hf_token")
                 ),
             ),
             server_extra_args=["--bar", "--pipeline-parallel-size=8"],
@@ -405,9 +402,7 @@ async def test_values_llm_generation_gpu_8x_pps_and_tps(
     mock_get_preset_gpu,
 ):
     apolo_client = setup_clients
-    input_processor = VLLMInferenceInputsProcessor(
-        client=apolo_client
-    )
+    input_processor = VLLMInferenceInputsProcessor(client=apolo_client)
 
     helm_params = await input_processor.gen_extra_values(
         input_=VLLMInferenceInputs(
@@ -418,8 +413,7 @@ async def test_values_llm_generation_gpu_8x_pps_and_tps(
                 name="test",
                 visibility="public",
                 hf_token=HuggingFaceToken(
-                    token_name="token1",
-                    token=ApoloSecret(key='hf_token')
+                    token_name="token1", token=ApoloSecret(key="hf_token")
                 ),
             ),
             server_extra_args=[
@@ -446,9 +440,7 @@ async def test_values_llm_generation__storage_integrated(
 ):
     hf_token = "test3"
     apolo_client = setup_clients
-    input_processor = VLLMInferenceInputsProcessor(
-        client=apolo_client
-    )
+    input_processor = VLLMInferenceInputsProcessor(client=apolo_client)
 
     helm_params = await input_processor.gen_extra_values(
         input_=VLLMInferenceInputs(
@@ -463,13 +455,12 @@ async def test_values_llm_generation__storage_integrated(
                 name="test",
                 visibility="public",
                 hf_token=HuggingFaceToken(
-                    token_name="token1",
-                    token=ApoloSecret(key=hf_token)
+                    token_name="token1", token=ApoloSecret(key=hf_token)
                 ),
                 files_path=ApoloFilesPath(
                     path="storage://some-cluster/some-org/some-proj/some-folder"
                 ),
-            )
+            ),
         ),
         apolo_client=apolo_client,
         app_type=AppType.LLMInference,
@@ -479,110 +470,115 @@ async def test_values_llm_generation__storage_integrated(
         app_id=APP_ID,
     )
 
-    assert helm_params == {
-        "serverExtraArgs": [],
-        "model": {"modelHFName": "test", "tokenizerHFName": ""},
-        "llm": {"modelHFName": "test", "tokenizerHFName": ""},
-        "env": {
-            "HUGGING_FACE_HUB_TOKEN": {
-                "valueFrom": {"secretKeyRef": {"name": "apps-secrets", "key": hf_token}}
-            }
-        },
-        "preset_name": "gpu-small",
-        "resources": {
-            "requests": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
-            "limits": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
-        },
-        "tolerations": [
-            {
-                "effect": "NoSchedule",
-                "key": "platform.neuromation.io/job",
-                "operator": "Exists",
-            },
-            {
-                "effect": "NoExecute",
-                "key": "node.kubernetes.io/not-ready",
-                "operator": "Exists",
-                "tolerationSeconds": 300,
-            },
-            {
-                "effect": "NoExecute",
-                "key": "node.kubernetes.io/unreachable",
-                "operator": "Exists",
-                "tolerationSeconds": 300,
-            },
-            {"effect": "NoSchedule", "key": "nvidia.com/gpu", "operator": "Exists"},
-        ],
-        "affinity": {
-            "nodeAffinity": {
-                "requiredDuringSchedulingIgnoredDuringExecution": {
-                    "nodeSelectorTerms": [
-                        {
-                            "matchExpressions": [
-                                {
-                                    "key": "platform.neuromation.io/nodepool",
-                                    "operator": "In",
-                                    "values": ["gpu_pool"],
-                                }
-                            ]
-                        }
-                    ]
+    assert (
+        helm_params
+        == {
+            "serverExtraArgs": [],
+            "model": {"modelHFName": "test", "tokenizerHFName": ""},
+            "llm": {"modelHFName": "test", "tokenizerHFName": ""},
+            "env": {
+                "HUGGING_FACE_HUB_TOKEN": {
+                    "valueFrom": {
+                        "secretKeyRef": {"name": "apps-secrets", "key": hf_token}
+                    }
                 }
-            }
-        },
-        "ingress": {
-            "enabled": True,
-            "grpc": {"enabled": False},
-            "annotations": {
-                "traefik.ingress.kubernetes.io/router.middlewares": (
-                    "platform-platform-control-plane-ingress-auth@kubernetescrd"
-                )
             },
-            "className": "traefik",
-            "hosts": [
+            "preset_name": "gpu-small",
+            "resources": {
+                "requests": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
+                "limits": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
+            },
+            "tolerations": [
                 {
-                    "host": f"{AppType.LLMInference.value}--"
-                    f"{APP_ID}.apps.some.org.neu.ro",
-                    "paths": [{"path": "/", "pathType": "Prefix", "portName": "http"}],
-                }
+                    "effect": "NoSchedule",
+                    "key": "platform.neuromation.io/job",
+                    "operator": "Exists",
+                },
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/not-ready",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300,
+                },
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/unreachable",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300,
+                },
+                {"effect": "NoSchedule", "key": "nvidia.com/gpu", "operator": "Exists"},
             ],
-        },
-        "podAnnotations": {
-            APOLO_STORAGE_LABEL: '[{"storage_uri": "storage://some-cluster/some-org/some-proj/some-folder", "mount_path": "/root/.cache/huggingface", "mount_mode": "rw"}]'  # noqa: E501
-        },
-        "podExtraLabels": {
-            APOLO_STORAGE_LABEL: "true",
-            APOLO_ORG_LABEL: "test-org",
-            APOLO_PROJECT_LABEL: "test-project",
-        },
-        "modelDownload": {"hookEnabled": True, "initEnabled": False},
-        "cache": {"enabled": False},
-        "nvidiaImage": {
-            "pullPolicy": "IfNotPresent",
-            "repository": "vllm/vllm-openai",
-            "tag": "v0.21.0"
-        },
-        "gpuProvider": "nvidia",
-        "podLabels": {
-            "platform.apolo.us/component": "app",
-            "platform.apolo.us/preset": "gpu-small",
-        },
-        "apolo_app_id": APP_ID,
-        "envNvidia": {
-            "PATH": "/usr/local/cuda/bin:/usr/local/sbin:"
-            "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(PATH)",
-            "LD_LIBRARY_PATH": "/usr/local/cuda/lib64:"
-            "/usr/local/nvidia/lib64:$(LD_LIBRARY_PATH)",
-        },
-    }
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "platform.neuromation.io/nodepool",
+                                        "operator": "In",
+                                        "values": ["gpu_pool"],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "ingress": {
+                "enabled": True,
+                "grpc": {"enabled": False},
+                "annotations": {
+                    "traefik.ingress.kubernetes.io/router.middlewares": (
+                        "platform-platform-control-plane-ingress-auth@kubernetescrd"
+                    )
+                },
+                "className": "traefik",
+                "hosts": [
+                    {
+                        "host": f"{AppType.LLMInference.value}--"
+                        f"{APP_ID}.apps.some.org.neu.ro",
+                        "paths": [
+                            {"path": "/", "pathType": "Prefix", "portName": "http"}
+                        ],
+                    }
+                ],
+            },
+            "podAnnotations": {
+                APOLO_STORAGE_LABEL: '[{"storage_uri": "storage://some-cluster/some-org/some-proj/some-folder", "mount_path": "/root/.cache/huggingface", "mount_mode": "rw"}]'  # noqa: E501
+            },
+            "podExtraLabels": {
+                APOLO_STORAGE_LABEL: "true",
+                APOLO_ORG_LABEL: "test-org",
+                APOLO_PROJECT_LABEL: "test-project",
+            },
+            "modelDownload": {"hookEnabled": True, "initEnabled": False},
+            "cache": {"enabled": False},
+            "nvidiaImage": {
+                "pullPolicy": "IfNotPresent",
+                "repository": "vllm/vllm-openai",
+                "tag": "v0.21.0",
+            },
+            "gpuProvider": "nvidia",
+            "podLabels": {
+                "platform.apolo.us/component": "app",
+                "platform.apolo.us/preset": "gpu-small",
+            },
+            "apolo_app_id": APP_ID,
+            "envNvidia": {
+                "PATH": "/usr/local/cuda/bin:/usr/local/sbin:"
+                "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(PATH)",
+                "LD_LIBRARY_PATH": "/usr/local/cuda/lib64:"
+                "/usr/local/nvidia/lib64:$(LD_LIBRARY_PATH)",
+            },
+        }
+    )
 
 
 async def test_values_llm_generation__autoscaling(setup_clients, mock_get_preset_gpu):
     hf_token = "test3"
     apolo_client = setup_clients
-    input_processor = VLLMInferenceInputsProcessor(
-        client=apolo_client
-    )
+    input_processor = VLLMInferenceInputsProcessor(client=apolo_client)
 
     helm_params = await input_processor.gen_extra_values(
         input_=VLLMInferenceInputs(
@@ -597,8 +593,7 @@ async def test_values_llm_generation__autoscaling(setup_clients, mock_get_preset
                 name="test",
                 visibility="public",
                 hf_token=HuggingFaceToken(
-                    token_name="token1",
-                    token=ApoloSecret(key=hf_token)
+                    token_name="token1", token=ApoloSecret(key=hf_token)
                 ),
                 files_path=ApoloFilesPath(
                     path="storage://some-cluster/some-org/some-proj/some-folder"
@@ -720,7 +715,8 @@ async def test_values_llm_generation_with_dynamic_model_no_cache(
 async def test_values_llm_generation_with_cached_dynamic_model(
     setup_clients, mock_get_preset_gpu
 ):
-    """Test values generation with HuggingFaceModelDetailDynamic when model is already cached.
+    """Test values generation with HuggingFaceModelDetailDynamic
+    when model is already cached.
 
     When cached=True and files_path is set, no download should happen - the model
     files are already on the storage mount.
@@ -796,6 +792,7 @@ async def test_values_llm_generation_with_hf_model_no_cache_no_token(
     # No storage integration labels without cache
     assert helm_params["podExtraLabels"] == {}
 
+
 async def test_values_llm_generation_with_hf_model_no_cache_token(
     setup_clients, mock_get_preset_gpu
 ):
@@ -808,7 +805,7 @@ async def test_values_llm_generation_with_hf_model_no_cache_token(
             token_name="mytoken",
             token=ApoloSecret(
                 key="sec",
-            )
+            ),
         ),
     )
 
@@ -835,3 +832,130 @@ async def test_values_llm_generation_with_hf_model_no_cache_token(
 
     # No storage integration labels without cache
     assert helm_params["podExtraLabels"] == {}
+
+
+async def test_values_llm_generation_with_hf_model_cache_token(
+    setup_clients, mock_get_preset_gpu
+):
+    apolo_client = setup_clients
+    input_processor = VLLMInferenceInputsProcessor(client=apolo_client)
+
+    model = HuggingFaceModel(
+        model_hf_name="meta-llama/Llama-2-7b-hf",
+        hf_token=HuggingFaceToken(
+            token_name="mytoken",
+            token=ApoloSecret(
+                key="sec",
+            ),
+        ),
+        hf_cache=HuggingFaceCache(
+            files_path=ApoloFilesPath(
+                path="storage://some-cluster/some-org/some-proj/tmp",
+            ),
+        ),
+    )
+
+    helm_params = await input_processor.gen_extra_values(
+        input_=VLLMInferenceInputs(
+            preset=Preset(name="gpu-small"),
+            ingress_http=IngressHttp(),
+            hugging_face_model=model,
+        ),
+        app_type=AppType.LLMInference,
+        app_name="llm",
+        namespace=DEFAULT_NAMESPACE,
+        app_secrets_name=APP_SECRETS_NAME,
+        app_id=APP_ID,
+    )
+
+    assert helm_params == {
+        "serverExtraArgs": [],
+        "model": {"modelHFName": "meta-llama/Llama-2-7b-hf", "tokenizerHFName": ""},
+        "llm": {"modelHFName": "meta-llama/Llama-2-7b-hf", "tokenizerHFName": ""},
+        "env": {
+            "HUGGING_FACE_HUB_TOKEN": {
+                "valueFrom": {"secretKeyRef": {"name": "apps-secrets", "key": "sec"}}
+            }
+        },
+        "envNvidia": {
+            "PATH": "/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(PATH)",  # noqa: E501
+            "LD_LIBRARY_PATH": "/usr/local/cuda/lib64:/usr/local/nvidia/lib64:$(LD_LIBRARY_PATH)",  # noqa: E501
+        },
+        "preset_name": "gpu-small",
+        "resources": {
+            "requests": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
+            "limits": {"cpu": "2000.0m", "memory": "0M", "nvidia.com/gpu": "1"},
+        },
+        "tolerations": [
+            {
+                "effect": "NoSchedule",
+                "key": "platform.neuromation.io/job",
+                "operator": "Exists",
+            },
+            {
+                "effect": "NoExecute",
+                "key": "node.kubernetes.io/not-ready",
+                "operator": "Exists",
+                "tolerationSeconds": 300,
+            },
+            {
+                "effect": "NoExecute",
+                "key": "node.kubernetes.io/unreachable",
+                "operator": "Exists",
+                "tolerationSeconds": 300,
+            },
+            {"effect": "NoSchedule", "key": "nvidia.com/gpu", "operator": "Exists"},
+        ],
+        "affinity": {
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "platform.neuromation.io/nodepool",
+                                    "operator": "In",
+                                    "values": ["gpu_pool"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "podLabels": {
+            "platform.apolo.us/component": "app",
+            "platform.apolo.us/preset": "gpu-small",
+        },
+        "ingress": {
+            "enabled": True,
+            "className": "traefik",
+            "hosts": [
+                {
+                    "host": "llm-inference--b1aeaf654526474ba22480d00e5b0109.apps.some.org.neu.ro",  # noqa: E501
+                    "paths": [{"path": "/", "pathType": "Prefix", "portName": "http"}],
+                }
+            ],
+            "annotations": {
+                "traefik.ingress.kubernetes.io/router.middlewares": "platform-platform-control-plane-ingress-auth@kubernetescrd"  # noqa: E501
+            },
+            "grpc": {"enabled": False},
+        },
+        "apolo_app_id": "b1aeaf654526474ba22480d00e5b0109",
+        "podAnnotations": {
+            "platform.apolo.us/inject-storage": '[{"storage_uri": "storage://some-cluster/some-org/some-proj/tmp", "mount_path": "/root/.cache/huggingface", "mount_mode": "rw"}]'  # noqa: E501
+        },
+        "podExtraLabels": {
+            "platform.apolo.us/inject-storage": "true",
+            "platform.apolo.us/org": "test-org",
+            "platform.apolo.us/project": "test-project",
+        },
+        "modelDownload": {"hookEnabled": False, "initEnabled": True},
+        "cache": {"enabled": False},
+        "gpuProvider": "nvidia",
+        "nvidiaImage": {
+            "repository": "vllm/vllm-openai",
+            "tag": "v0.21.0",
+            "pullPolicy": "IfNotPresent",
+        },
+    }

--- a/.apolo/tests/unit/llm/test_outputs_generation.py
+++ b/.apolo/tests/unit/llm/test_outputs_generation.py
@@ -1,5 +1,4 @@
 import pytest
-
 from apolo_apps_llm_inference.outputs_processor import VLLMInferenceOutputsProcessor
 
 
@@ -32,8 +31,9 @@ async def test_llm(setup_clients, mock_kubernetes_client, app_instance_id):
     assert res["embeddings_api"]["external_url"]["host"] == "example.com"
 
 
+@pytest.mark.usefixtures("_mock_fetch_models")
 async def test_llm_without_server_args(
-    setup_clients, mock_kubernetes_client, app_instance_id, mock_fetch_models
+    setup_clients, mock_kubernetes_client, app_instance_id
 ):
     res = await VLLMInferenceOutputsProcessor().generate_outputs(
         helm_values={
@@ -86,7 +86,7 @@ async def test_llm_with_model_max_lenth(
     assert res["hugging_face_model"] == {
         "model_hf_name": "meta-llama/Llama-3.1-8B-Instruct",
         "hf_token": None,
-        'hf_cache': None,
+        "hf_cache": None,
         "__type__": "HuggingFaceModel",
     }
     assert res["tokenizer_hf_name"] == "meta-llama/Llama-3.1-8B-Instruct"
@@ -101,6 +101,7 @@ async def test_llm_with_model_max_lenth(
         "context_max_tokens": max_model_len,
         "__type__": "LLMModelConfig",
     }
+
 
 async def test_llm_without_model(
     setup_clients, mock_kubernetes_client, app_instance_id

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,12 @@ repos:
     rev: v0.1.30
     hooks:
       - id: helmlint
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
   - repo: local
     hooks:
       - id: generate-types-schemas

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,18 @@ install setup:
 	poetry install --with dev
 	poetry run pre-commit install;
 
-.PHONY: lint format
-lint format:
+.PHONY: format
+format:
 ifdef CI
 	poetry run pre-commit run --all-files --show-diff-on-failure
 else
 	# automatically fix the formatting issues and rerun again
 	poetry run pre-commit run --all-files || poetry run pre-commit run --all-files
 endif
+
+.PHONY:
+lint: format
+	cd .apolo/src && poetry run mypy --explicit-package-bases apolo_apps_llm_inference
 
 .PHONY: test-unit
 test-unit:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 
 .PHONY:
 lint: format
-	cd .apolo/src && poetry run mypy --explicit-package-bases apolo_apps_llm_inference
+	poetry run mypy .apolo
 
 .PHONY: test-unit
 test-unit:

--- a/charts/llm-inference-app/values.yaml
+++ b/charts/llm-inference-app/values.yaml
@@ -22,7 +22,7 @@ replicaCount: 1
 image:
   repository: vllm/vllm-openai
   pullPolicy: IfNotPresent
-  tag: v0.13.0
+  tag: v0.21.0
   imagePullSecrets: []
 
 resources: {}


### PR DESCRIPTION
changes:
- added back support of raw HF model (currently we were only able to deploy via HF proxy app), adjusted processor and tests for that
- bumped vLLM version v0.13.0 -> v0.21.0

misc:
- added ruff, mypy, fixed failures, reformatted code (the most of the changes from ruff)